### PR TITLE
Scaffold Stage 0 JsonApiBundle skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.2', '8.3', '8.4']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          tools: composer
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: PHPStan
+        run: make stan
+
+      - name: PHPUnit
+        run: make test
+
+      - name: PHP CS Fixer (dry-run)
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/vendor/
+/composer.lock
+/.php-cs-fixer.cache
+/.infection/
+infection.log
+/.phpunit.result.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = Finder::create()
+    ->in(__DIR__ . '/src')
+    ->in(__DIR__ . '/tests')
+;
+
+return (new Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12' => true,
+        'declare_strict_types' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'phpdoc_align' => ['align' => 'vertical'],
+        'phpdoc_to_comment' => false,
+        'native_constant_invocation' => ['include' => ['@compiler_optimized']],
+    ])
+    ->setFinder($finder)
+;

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+conduct@example.com. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+https://github.com/mozilla/diversity.
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Thank you for helping us build a first-class JSON:API experience on Symfony!
+
+## Setup
+
+```bash
+composer install
+```
+
+## Quality gates
+
+* `make test`
+* `make stan`
+* `make cs-fix --dry-run`
+* `make rector`
+
+Please ensure new code adheres to PSR-12, is fully typed, and includes appropriate test coverage.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 JsonApi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test stan cs-fix rector
+
+test:
+vendor/bin/phpunit
+
+stan:
+vendor/bin/phpstan analyse
+
+cs-fix:
+vendor/bin/php-cs-fixer fix
+
+rector:
+vendor/bin/rector process

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
-# jsonapi-symfony
+# JsonApiBundle (Stage 0)
+
+A DX-first Symfony 7 bundle scaffold for building fully compliant JSON:API 1.1 backends.
+
+## Installation
+
+```bash
+composer require jsonapi/symfony-jsonapi-bundle
+```
+
+For local development against this repository:
+
+```bash
+git clone https://github.com/your-org/jsonapi-symfony.git
+cd jsonapi-symfony
+composer install
+```
+
+## Usage
+
+Register the bundle in your Symfony application's `config/bundles.php`:
+
+```php
+return [
+    JsonApi\Symfony\Bridge\Symfony\Bundle\JsonApiBundle::class => ['all' => true],
+];
+```
+
+Configure the bundle (defaults shown):
+
+```yaml
+# config/packages/jsonapi.yaml
+jsonapi:
+    strict_content_negotiation: true
+    media_type: 'application/vnd.api+json'
+```
+
+Declare your first resource:
+
+```php
+use JsonApi\Symfony\Resource\Attribute\JsonApiResource;
+use JsonApi\Symfony\Resource\Attribute\Id;
+use JsonApi\Symfony\Resource\Attribute\Attribute;
+use JsonApi\Symfony\Resource\Attribute\Relationship;
+
+#[JsonApiResource(type: 'articles')]
+final class Article
+{
+    #[Id]
+    public string $id;
+
+    #[Attribute]
+    public string $title;
+
+    #[Relationship(toMany: true)]
+    public array $comments = [];
+}
+```
+
+Stage 0 delivers:
+
+* Bundle skeleton with configuration tree and attribute autoconfiguration.
+* Strict media-type negotiation stub returning 406/415 according to JSON:API 1.1.
+* Foundational DX tooling: PHPUnit, PHPStan, CS Fixer, Rector, Infection.
+
+Subsequent stages will add read/write endpoints, metadata registry, document building, Atomic Operations, and more.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,44 @@
+{
+  "name": "jsonapi/symfony-jsonapi-bundle",
+  "description": "JSON:API 1.1 bundle for Symfony 7 with DX-first design",
+  "type": "symfony-bundle",
+  "license": "MIT",
+  "require": {
+    "php": "^8.2",
+    "symfony/dependency-injection": "^7.1",
+    "symfony/config": "^7.1",
+    "symfony/http-kernel": "^7.1",
+    "symfony/event-dispatcher": "^7.1",
+    "symfony/http-foundation": "^7.1"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^11.0",
+    "symfony/phpunit-bridge": "^7.1",
+    "phpstan/phpstan": "^1.11",
+    "friendsofphp/php-cs-fixer": "^3.64",
+    "rector/rector": "^1.0",
+    "infection/infection": "^0.29"
+  },
+  "autoload": {
+    "psr-4": {
+      "JsonApi\\Symfony\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "JsonApi\\Symfony\\Tests\\": "tests/"
+    }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-main": "0.1-dev"
+    }
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true,
+  "config": {
+    "allow-plugins": {
+      "infection/extension-installer": true
+    }
+  }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use JsonApi\Symfony\Bridge\Symfony\EventSubscriber\ContentNegotiationSubscriber;
+use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistry;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    $services
+        ->set(ContentNegotiationSubscriber::class)
+        ->args([
+            '%jsonapi.strict_content_negotiation%',
+            '%jsonapi.media_type%',
+        ])
+        ->tag('kernel.event_subscriber')
+    ;
+
+    $services->set(JsonApiHttpException::class)->abstract();
+    $services->set(ResourceRegistry::class);
+};

--- a/infection.json5
+++ b/infection.json5
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://infection.github.io/schema.json",
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "infection.log"
+    },
+    "tmpDir": ".infection"
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,17 @@
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+
+parameters:
+    level: 8
+    paths:
+        - src
+        - tests
+    bootstrapFiles:
+        - tests/bootstrap.php
+    treatPhpDocTypesAsCertain: true
+    checkMissingIterableValueType: true
+    checkGenericClassInNonGenericObjectType: true
+    reportUnmatchedIgnoredErrors: true
+    checkMissingCallableSignature: true
+    checkExplicitMixed: true
+    checkBenevolentUnionTypes: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheResult="false"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Functional">
+            <directory>tests/Functional</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_82,
+    ]);
+};

--- a/src/Bridge/Symfony/Bundle/JsonApiBundle.php
+++ b/src/Bridge/Symfony/Bundle/JsonApiBundle.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Bridge\Symfony\Bundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @psalm-suppress MissingConstructor
+ */
+final class JsonApiBundle extends Bundle
+{
+}

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Bridge\Symfony\DependencyInjection;
+
+use JsonApi\Symfony\Http\Negotiation\MediaType;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+final class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('jsonapi');
+
+        /** @var ArrayNodeDefinition $rootNode */
+        $rootNode = $treeBuilder->getRootNode();
+
+        /** @var NodeBuilder $children */
+        $children = $rootNode->children();
+        $children->booleanNode('strict_content_negotiation')
+            ->defaultTrue()
+        ;
+
+        /** @var NodeBuilder $children */
+        $children = $rootNode->children();
+        $children->scalarNode('media_type')
+            ->defaultValue(MediaType::JSON_API)
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/Bridge/Symfony/DependencyInjection/JsonApiExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/JsonApiExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Bridge\Symfony\DependencyInjection;
+
+use JsonApi\Symfony\Resource\Attribute\JsonApiResource;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+final class JsonApiExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setParameter('jsonapi.strict_content_negotiation', $config['strict_content_negotiation']);
+        $container->setParameter('jsonapi.media_type', $config['media_type']);
+
+        $this->registerAutoconfiguration($container);
+
+        $configDirectory = __DIR__ . '/../../../../config';
+        if (is_dir($configDirectory)) {
+            $loader = new PhpFileLoader($container, new FileLocator($configDirectory));
+            $loader->load('services.php');
+        }
+    }
+
+    private function registerAutoconfiguration(ContainerBuilder $container): void
+    {
+        $container->registerAttributeForAutoconfiguration(
+            JsonApiResource::class,
+            static function (ChildDefinition $definition, JsonApiResource $attribute): void {
+                $definition->addTag('jsonapi.resource', ['type' => $attribute->type]);
+            }
+        );
+    }
+}

--- a/src/Bridge/Symfony/EventSubscriber/ContentNegotiationSubscriber.php
+++ b/src/Bridge/Symfony/EventSubscriber/ContentNegotiationSubscriber.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Bridge\Symfony\EventSubscriber;
+
+use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class ContentNegotiationSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly bool $strictContentNegotiation,
+        private readonly string $mediaType
+    ) {
+    }
+
+    /**
+     * @return array<string, array{0: string, 1?: int}>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 512],
+            KernelEvents::RESPONSE => ['onKernelResponse', -512],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if (!$this->strictContentNegotiation) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        $this->assertContentType($request);
+        $this->assertAcceptHeader($request);
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        self::addVaryAccept($response);
+    }
+
+    private function assertContentType(Request $request): void
+    {
+        $contentType = $request->headers->get('Content-Type');
+        if ($contentType === null) {
+            return;
+        }
+
+        if ($this->mediaType !== $this->normalizeMediaType($contentType)) {
+            throw JsonApiHttpException::unsupportedMediaType('JSON:API requires the "application/vnd.api+json" media type.');
+        }
+    }
+
+    private function assertAcceptHeader(Request $request): void
+    {
+        $accept = $request->headers->get('Accept');
+        if ($accept === null || $accept === '') {
+            return;
+        }
+
+        foreach (explode(',', $accept) as $part) {
+            if ($this->mediaType === $this->normalizeMediaType($part)) {
+                return;
+            }
+        }
+
+        throw JsonApiHttpException::notAcceptable('Requested representation is not available in application/vnd.api+json.');
+    }
+
+    private function normalizeMediaType(string $value): string
+    {
+        $normalized = trim(strtolower($value));
+        $semicolonPosition = strpos($normalized, ';');
+
+        if ($semicolonPosition === false) {
+            return $normalized;
+        }
+
+        return substr($normalized, 0, $semicolonPosition);
+    }
+
+    private static function addVaryAccept(Response $response): void
+    {
+        $response->headers->set('Vary', self::mergeVaryHeader($response, 'Accept'), false);
+    }
+
+    private static function mergeVaryHeader(Response $response, string $value): string
+    {
+        $existing = $response->headers->get('Vary');
+
+        if ($existing === null || $existing === '') {
+            return $value;
+        }
+
+        $values = array_map('trim', explode(',', $existing));
+        if (!in_array($value, $values, true)) {
+            $values[] = $value;
+        }
+
+        return implode(', ', $values);
+    }
+}

--- a/src/Contract/Resource/ResourceMetadataInterface.php
+++ b/src/Contract/Resource/ResourceMetadataInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Resource;
+
+interface ResourceMetadataInterface
+{
+    public function getType(): string;
+}

--- a/src/Http/Exception/JsonApiHttpException.php
+++ b/src/Http/Exception/JsonApiHttpException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class JsonApiHttpException extends HttpException
+{
+    public static function notAcceptable(string $message = 'Not Acceptable'): self
+    {
+        return new self(406, $message);
+    }
+
+    public static function unsupportedMediaType(string $message = 'Unsupported Media Type'): self
+    {
+        return new self(415, $message);
+    }
+}

--- a/src/Http/Negotiation/MediaType.php
+++ b/src/Http/Negotiation/MediaType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Negotiation;
+
+final class MediaType
+{
+    public const JSON_API = 'application/vnd.api+json';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Resource/Attribute/Attribute.php
+++ b/src/Resource/Attribute/Attribute.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Resource\Attribute;
+
+use Attribute as PhpAttribute;
+
+#[PhpAttribute(PhpAttribute::TARGET_PROPERTY | PhpAttribute::TARGET_METHOD)]
+final class Attribute
+{
+    public function __construct(
+        public readonly ?string $name = null,
+        public readonly bool $readable = true,
+        public readonly bool $writable = true,
+    ) {
+    }
+}

--- a/src/Resource/Attribute/Id.php
+++ b/src/Resource/Attribute/Id.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Resource\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+final class Id
+{
+}

--- a/src/Resource/Attribute/JsonApiResource.php
+++ b/src/Resource/Attribute/JsonApiResource.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Resource\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class JsonApiResource
+{
+    public function __construct(
+        public readonly string $type,
+        public readonly ?string $routePrefix = null,
+        public readonly ?string $description = null,
+        public readonly bool $exposeId = true,
+    ) {
+    }
+}

--- a/src/Resource/Attribute/Relationship.php
+++ b/src/Resource/Attribute/Relationship.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Resource\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+final class Relationship
+{
+    public function __construct(
+        public readonly bool $toMany = false,
+        public readonly ?string $inverse = null,
+    ) {
+    }
+}

--- a/src/Resource/Registry/ResourceRegistry.php
+++ b/src/Resource/Registry/ResourceRegistry.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Resource\Registry;
+
+use JsonApi\Symfony\Contract\Resource\ResourceMetadataInterface;
+
+/**
+ * @internal Stage 0 placeholder.
+ */
+class ResourceRegistry
+{
+    /**
+     * @var array<string, ResourceMetadataInterface>
+     */
+    private array $resources = [];
+
+    public function register(ResourceMetadataInterface $metadata): void
+    {
+        $this->resources[$metadata->getType()] = $metadata;
+    }
+
+    /**
+     * @return array<string, ResourceMetadataInterface>
+     */
+    public function all(): array
+    {
+        return $this->resources;
+    }
+}

--- a/tests/Functional/ContentNegotiationTest.php
+++ b/tests/Functional/ContentNegotiationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional;
+
+use JsonApi\Symfony\Bridge\Symfony\EventSubscriber\ContentNegotiationSubscriber;
+use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
+use JsonApi\Symfony\Http\Negotiation\MediaType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+#[CoversClass(ContentNegotiationSubscriber::class)]
+final class ContentNegotiationTest extends TestCase
+{
+    private ContentNegotiationSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->subscriber = new ContentNegotiationSubscriber(true, MediaType::JSON_API);
+    }
+
+    public function testUnsupportedMediaTypeTriggers415(): void
+    {
+        $request = Request::create('/articles', 'POST', server: ['CONTENT_TYPE' => 'application/json']);
+        $event = new RequestEvent($this->createKernel(), $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->expectException(JsonApiHttpException::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('JSON:API requires the "application/vnd.api+json" media type.');
+
+        $this->subscriber->onKernelRequest($event);
+    }
+
+    public function testNotAcceptableTriggers406(): void
+    {
+        $request = Request::create('/articles', 'GET', server: ['HTTP_ACCEPT' => 'application/json']);
+        $event = new RequestEvent($this->createKernel(), $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->expectException(JsonApiHttpException::class);
+        $this->expectExceptionMessage('Requested representation is not available in application/vnd.api+json.');
+
+        $this->subscriber->onKernelRequest($event);
+    }
+
+    public function testResponseContainsVaryAccept(): void
+    {
+        $response = new Response();
+        $event = new ResponseEvent(
+            $this->createKernel(),
+            Request::create('/articles', 'GET'),
+            HttpKernelInterface::MAIN_REQUEST,
+            $response
+        );
+
+        $this->subscriber->onKernelResponse($event);
+
+        self::assertSame('Accept', $response->headers->get('Vary'));
+    }
+
+    private function createKernel(): HttpKernelInterface
+    {
+        return new class () implements HttpKernelInterface {
+            public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): Response
+            {
+                return new Response();
+            }
+        };
+    }
+}

--- a/tests/Unit/AttributeAutoconfigurationTest.php
+++ b/tests/Unit/AttributeAutoconfigurationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Unit;
+
+use JsonApi\Symfony\Bridge\Symfony\DependencyInjection\JsonApiExtension;
+use JsonApi\Symfony\Resource\Attribute\JsonApiResource;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+#[CoversClass(JsonApiExtension::class)]
+final class AttributeAutoconfigurationTest extends TestCase
+{
+    public function testResourceAttributeRegistersTag(): void
+    {
+        $container = new ContainerBuilder();
+        $extension = new JsonApiExtension();
+
+        $extension->load([], $container);
+
+        $container->register(ResourceFixture::class)
+            ->setAutoconfigured(true)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        $definition = $container->getDefinition(ResourceFixture::class);
+        self::assertTrue($definition->hasTag('jsonapi.resource'));
+
+        $tags = $definition->getTag('jsonapi.resource');
+        self::assertSame('articles', $tags[0]['type']);
+    }
+}
+
+#[JsonApiResource(type: 'articles')]
+final class ResourceFixture
+{
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Summary
- create the JsonApiBundle foundation with configuration tree and attribute autoconfiguration
- add strict JSON:API media-type negotiation subscriber and resource attribute markers
- provide Stage 0 tooling, CI workflow, and contributor documentation

## Testing
- vendor/bin/phpunit
- vendor/bin/phpstan analyse
- vendor/bin/php-cs-fixer fix --dry-run --diff

------
https://chatgpt.com/codex/tasks/task_e_68e2c728d69c832f90a97dadfbfda0e6