### PR TITLE
Implement JSON:API read endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JsonApiBundle (Stage 0)
+# JsonApiBundle (Stage 1)
 
 A DX-first Symfony 7 bundle scaffold for building fully compliant JSON:API 1.1 backends.
 
@@ -33,6 +33,14 @@ Configure the bundle (defaults shown):
 jsonapi:
     strict_content_negotiation: true
     media_type: 'application/vnd.api+json'
+    route_prefix: '/api'
+    pagination:
+        default_size: 25
+        max_size: 100
+    sorting:
+        whitelist:
+            articles: ['title', 'createdAt']
+            authors: ['name']
 ```
 
 Declare your first resource:
@@ -57,10 +65,56 @@ final class Article
 }
 ```
 
-Stage 0 delivers:
+Stage 1 ships fully functional read endpoints:
 
-* Bundle skeleton with configuration tree and attribute autoconfiguration.
-* Strict media-type negotiation stub returning 406/415 according to JSON:API 1.1.
-* Foundational DX tooling: PHPUnit, PHPStan, CS Fixer, Rector, Infection.
+* Attribute-driven metadata registry with automatic discovery of attributes and relationships.
+* `GET /api/{type}` and `GET /api/{type}/{id}` controllers with JSON:API 1.1 compliant documents.
+* Query parsing for `include`, `fields[TYPE]`, `sort`, `page[number]`, and `page[size]` with robust validation.
+* Pagination helpers generating `self`, `first`, `prev`, `next`, and `last` links that retain other query parameters.
+* Document builder producing `data`, `included`, `links`, `meta`, and `jsonapi.version` for any combination of sparse fieldsets and includes.
+* In-memory repository and sample fixtures (Article, Author, Tag) for functional testing.
 
-Subsequent stages will add read/write endpoints, metadata registry, document building, Atomic Operations, and more.
+Example response:
+
+```json
+{
+  "jsonapi": { "version": "1.1" },
+  "links": {
+    "self": "https://api.example.test/api/articles?page[number]=2&page[size]=5",
+    "first": "https://api.example.test/api/articles?page[number]=1&page[size]=5",
+    "prev": "https://api.example.test/api/articles?page[number]=1&page[size]=5",
+    "next": "https://api.example.test/api/articles?page[number]=3&page[size]=5",
+    "last": "https://api.example.test/api/articles?page[number]=3&page[size]=5"
+  },
+  "data": [
+    {
+      "type": "articles",
+      "id": "42",
+      "attributes": {
+        "title": "Hello JSON:API",
+        "createdAt": "2024-06-01T12:00:00+00:00"
+      },
+      "links": {
+        "self": "https://api.example.test/api/articles/42"
+      }
+    }
+  ],
+  "included": [
+    {
+      "type": "authors",
+      "id": "7",
+      "attributes": { "name": "Alice" },
+      "links": {
+        "self": "https://api.example.test/api/authors/7"
+      }
+    }
+  ],
+  "meta": {
+    "total": 123,
+    "page": 2,
+    "size": 5
+  }
+}
+```
+
+Upcoming stages will introduce persistence adapters, relationship endpoints, write operations, and JSON:API error documents.

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
     "symfony/config": "^7.1",
     "symfony/http-kernel": "^7.1",
     "symfony/event-dispatcher": "^7.1",
-    "symfony/http-foundation": "^7.1"
+    "symfony/http-foundation": "^7.1",
+    "symfony/routing": "^7.1",
+    "symfony/property-access": "^7.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^11.0",

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -31,6 +31,30 @@ final class Configuration implements ConfigurationInterface
             ->defaultValue(MediaType::JSON_API)
         ;
 
+        $children->scalarNode('route_prefix')
+            ->defaultValue('/api')
+        ;
+
+        $children->arrayNode('pagination')
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->integerNode('default_size')->min(1)->defaultValue(25)->end()
+                ->integerNode('max_size')->min(1)->defaultValue(100)->end()
+            ->end()
+        ;
+
+        $children->arrayNode('sorting')
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('whitelist')
+                    ->useAttributeAsKey('type')
+                    ->arrayPrototype()
+                        ->scalarPrototype()->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
         return $treeBuilder;
     }
 }

--- a/src/Bridge/Symfony/DependencyInjection/JsonApiExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/JsonApiExtension.php
@@ -20,6 +20,10 @@ final class JsonApiExtension extends Extension
 
         $container->setParameter('jsonapi.strict_content_negotiation', $config['strict_content_negotiation']);
         $container->setParameter('jsonapi.media_type', $config['media_type']);
+        $container->setParameter('jsonapi.route_prefix', $config['route_prefix']);
+        $container->setParameter('jsonapi.pagination.default_size', $config['pagination']['default_size']);
+        $container->setParameter('jsonapi.pagination.max_size', $config['pagination']['max_size']);
+        $container->setParameter('jsonapi.sorting.whitelist', $config['sorting']['whitelist']);
 
         $this->registerAutoconfiguration($container);
 

--- a/src/Contract/Data/ResourceIdentifier.php
+++ b/src/Contract/Data/ResourceIdentifier.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Data;
+
+final class ResourceIdentifier
+{
+    public function __construct(
+        public string $type,
+        public string $id,
+    ) {
+    }
+}

--- a/src/Contract/Data/ResourceRepository.php
+++ b/src/Contract/Data/ResourceRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Data;
+
+use JsonApi\Symfony\Query\Criteria;
+
+interface ResourceRepository
+{
+    public function findCollection(string $type, Criteria $criteria): Slice;
+
+    public function findOne(string $type, string $id, Criteria $criteria): ?object;
+
+    /**
+     * @param list<ResourceIdentifier> $identifiers
+     *
+     * @return iterable<object>
+     */
+    public function findRelated(string $type, string $relationship, array $identifiers): iterable;
+}

--- a/src/Contract/Data/Slice.php
+++ b/src/Contract/Data/Slice.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Data;
+
+final class Slice
+{
+    /**
+     * @param list<object> $items
+     */
+    public function __construct(
+        public array $items,
+        public int $pageNumber,
+        public int $pageSize,
+        public int $totalItems,
+    ) {
+    }
+}

--- a/src/Http/Controller/CollectionController.php
+++ b/src/Http/Controller/CollectionController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Controller;
+
+use JsonApi\Symfony\Contract\Data\ResourceRepository;
+use JsonApi\Symfony\Http\Document\DocumentBuilder;
+use JsonApi\Symfony\Http\Request\QueryParser;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+#[Route(path: '/api/{type}', name: 'jsonapi.collection', methods: ['GET'])]
+final class CollectionController
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly ResourceRepository $repository,
+        private readonly QueryParser $parser,
+        private readonly DocumentBuilder $document,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $type): JsonResponse
+    {
+        if (!$this->registry->hasType($type)) {
+            throw new NotFoundHttpException(sprintf('Resource type "%s" not found.', $type));
+        }
+
+        $criteria = $this->parser->parse($type, $request);
+        $slice = $this->repository->findCollection($type, $criteria);
+        $document = $this->document->buildCollection($type, $slice->items, $criteria, $slice, $request);
+
+        return $this->createResponse($document);
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     */
+    private function createResponse(array $document): JsonResponse
+    {
+        $response = new JsonResponse($document, Response::HTTP_OK);
+        $response->headers->set('Content-Type', 'application/vnd.api+json');
+
+        return $response;
+    }
+}

--- a/src/Http/Controller/ResourceController.php
+++ b/src/Http/Controller/ResourceController.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Controller;
+
+use JsonApi\Symfony\Contract\Data\ResourceRepository;
+use JsonApi\Symfony\Http\Document\DocumentBuilder;
+use JsonApi\Symfony\Http\Request\QueryParser;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/api/{type}/{id}', name: 'jsonapi.resource', methods: ['GET'])]
+final class ResourceController
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly ResourceRepository $repository,
+        private readonly QueryParser $parser,
+        private readonly DocumentBuilder $document,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $type, string $id): JsonResponse
+    {
+        if (!$this->registry->hasType($type)) {
+            throw new NotFoundHttpException(sprintf('Resource type "%s" not found.', $type));
+        }
+
+        $criteria = $this->parser->parse($type, $request);
+        $model = $this->repository->findOne($type, $id, $criteria);
+
+        if ($model === null) {
+            throw new NotFoundHttpException(sprintf('Resource "%s" with id "%s" was not found.', $type, $id));
+        }
+
+        $document = $this->document->buildResource($type, $model, $criteria, $request);
+
+        return $this->createResponse($document);
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     */
+    private function createResponse(array $document): JsonResponse
+    {
+        $response = new JsonResponse($document, Response::HTTP_OK);
+        $response->headers->set('Content-Type', 'application/vnd.api+json');
+
+        return $response;
+    }
+}

--- a/src/Http/Document/DocumentBuilder.php
+++ b/src/Http/Document/DocumentBuilder.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Document;
+
+use JsonApi\Symfony\Contract\Data\Slice;
+use JsonApi\Symfony\Http\Link\LinkGenerator;
+use JsonApi\Symfony\Query\Criteria;
+use JsonApi\Symfony\Resource\Metadata\AttributeMetadata;
+use JsonApi\Symfony\Resource\Metadata\RelationshipMetadata;
+use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use stdClass;
+use Stringable;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+final class DocumentBuilder
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly PropertyAccessorInterface $accessor,
+        private readonly LinkGenerator $links,
+    ) {
+    }
+
+    /**
+     * @param list<object> $models
+     */
+    public function buildCollection(string $type, array $models, Criteria $criteria, Slice $slice, Request $request): array
+    {
+        $data = [];
+        $included = [];
+        $visited = [];
+        $includeTree = $this->buildIncludeTree($criteria);
+
+        foreach ($models as $model) {
+            $data[] = $this->buildResourceObject($type, $model, $criteria);
+            if ($includeTree !== []) {
+                $this->gatherIncluded($type, $model, $includeTree, $criteria, $included, $visited);
+            }
+        }
+
+        $document = [
+            'jsonapi' => ['version' => '1.1'],
+            'links' => array_merge(
+                ['self' => $this->links->topLevelSelf($request)],
+                $this->links->collectionPagination($type, $criteria->pagination, $slice->totalItems, $request),
+            ),
+            'data' => $data,
+            'meta' => [
+                'total' => $slice->totalItems,
+                'page' => $slice->pageNumber,
+                'size' => $slice->pageSize,
+            ],
+        ];
+
+        if ($included !== []) {
+            $document['included'] = array_values($included);
+        }
+
+        return $document;
+    }
+
+    public function buildResource(string $type, object $model, Criteria $criteria, Request $request): array
+    {
+        $includeTree = $this->buildIncludeTree($criteria);
+        $included = [];
+        $visited = [];
+
+        if ($includeTree !== []) {
+            $this->gatherIncluded($type, $model, $includeTree, $criteria, $included, $visited);
+        }
+
+        $document = [
+            'jsonapi' => ['version' => '1.1'],
+            'links' => ['self' => $this->links->topLevelSelf($request)],
+            'data' => $this->buildResourceObject($type, $model, $criteria),
+        ];
+
+        if ($included !== []) {
+            $document['included'] = array_values($included);
+        }
+
+        return $document;
+    }
+
+    private function buildResourceObject(string $type, object $model, Criteria $criteria): array
+    {
+        $metadata = $this->registry->getByType($type);
+        $fields = $criteria->fields[$type] ?? null;
+        $attributes = $this->buildAttributes($metadata, $model, $fields);
+        $id = $this->resolveId($metadata, $model);
+
+        $resource = [
+            'type' => $type,
+            'id' => $id,
+            'links' => [
+                'self' => $this->links->resourceSelf($type, $id),
+            ],
+        ];
+
+        $resource['attributes'] = $attributes === [] ? new stdClass() : $attributes;
+
+        return $resource;
+    }
+
+    /**
+     * @param list<string>|null $fields
+     *
+     * @return array<string, mixed>
+     */
+    private function buildAttributes(ResourceMetadata $metadata, object $model, ?array $fields): array
+    {
+        $attributes = [];
+        $restrict = $fields !== null;
+
+        /** @var AttributeMetadata $attribute */
+        foreach ($metadata->attributes as $name => $attribute) {
+            if (!$attribute->readable) {
+                continue;
+            }
+
+            if ($restrict && !in_array($name, $fields, true)) {
+                continue;
+            }
+
+            $value = $this->accessor->getValue($model, $attribute->propertyPath ?? $name);
+            $attributes[$name] = $this->normalizeAttributeValue($value);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $includeTree
+     * @param array<string, array<string, mixed>> $included
+     * @param array<string, bool>                 $visited
+     */
+    private function gatherIncluded(string $type, object $model, array $includeTree, Criteria $criteria, array &$included, array &$visited): void
+    {
+        if ($includeTree === []) {
+            return;
+        }
+
+        $metadata = $this->registry->getByType($type);
+
+        foreach ($includeTree as $relationshipName => $children) {
+            if (!isset($metadata->relationships[$relationshipName])) {
+                continue;
+            }
+
+            /** @var RelationshipMetadata $relationship */
+            $relationship = $metadata->relationships[$relationshipName];
+            $propertyPath = $relationship->propertyPath ?? $relationshipName;
+            $related = $this->accessor->getValue($model, $propertyPath);
+
+            if ($related === null) {
+                continue;
+            }
+
+            $relatedItems = $relationship->toMany ? $this->normalizeToMany($related) : [$related];
+
+            foreach ($relatedItems as $relatedItem) {
+                if (!is_object($relatedItem)) {
+                    continue;
+                }
+
+                $relatedType = $relationship->targetType;
+                if ($relatedType === null) {
+                    $metadataForClass = $this->registry->getByClass($relatedItem::class);
+                    if ($metadataForClass === null) {
+                        continue;
+                    }
+
+                    $relatedType = $metadataForClass->type;
+                }
+
+                $resource = $this->buildResourceObject($relatedType, $relatedItem, $criteria);
+                $identifier = $resource['type'] . ':' . $resource['id'];
+
+                if (!isset($visited[$identifier])) {
+                    $visited[$identifier] = true;
+                    $included[$identifier] = $resource;
+                    if ($children !== []) {
+                        $this->gatherIncluded($relatedType, $relatedItem, $children, $criteria, $included, $visited);
+                    }
+                } elseif ($children !== []) {
+                    $this->gatherIncluded($relatedType, $relatedItem, $children, $criteria, $included, $visited);
+                }
+            }
+        }
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function buildIncludeTree(Criteria $criteria): array
+    {
+        $tree = [];
+
+        foreach ($criteria->include as $path) {
+            $segments = explode('.', $path);
+            $cursor = &$tree;
+            foreach ($segments as $segment) {
+                if (!isset($cursor[$segment])) {
+                    $cursor[$segment] = [];
+                }
+                $cursor = &$cursor[$segment];
+            }
+            unset($cursor);
+        }
+
+        return $tree;
+    }
+
+    private function resolveId(ResourceMetadata $metadata, object $model): string
+    {
+        $propertyPath = $metadata->idPropertyPath ?? 'id';
+        $value = $this->accessor->getValue($model, $propertyPath);
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        throw new \RuntimeException(sprintf('Unable to resolve resource identifier for %s.', $metadata->class));
+    }
+
+    private function normalizeAttributeValue(mixed $value): mixed
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format(DATE_ATOM);
+        }
+
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function normalizeToMany(mixed $value): array
+    {
+        if (is_array($value)) {
+            return array_values(array_filter($value, static fn ($item) => $item !== null));
+        }
+
+        if ($value instanceof \Traversable) {
+            $result = [];
+            foreach ($value as $item) {
+                if ($item !== null) {
+                    $result[] = $item;
+                }
+            }
+
+            return $result;
+        }
+
+        return [];
+    }
+}

--- a/src/Http/Link/LinkGenerator.php
+++ b/src/Http/Link/LinkGenerator.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Link;
+
+use JsonApi\Symfony\Query\Pagination;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class LinkGenerator
+{
+    public function __construct(private readonly UrlGeneratorInterface $urls)
+    {
+    }
+
+    public function topLevelSelf(Request $request): string
+    {
+        return $request->getUri();
+    }
+
+    public function resourceSelf(string $type, string $id): string
+    {
+        return $this->urls->generate(
+            'jsonapi.resource',
+            ['type' => $type, 'id' => $id],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function collectionPagination(string $type, Pagination $pagination, int $total, Request $request): array
+    {
+        $query = $request->query->all();
+        $links = [];
+        $size = $pagination->size;
+        $number = $pagination->number;
+        $totalPages = max(1, (int) ceil($total / max($size, 1)));
+
+        $links['first'] = $this->generateCollectionUrl($type, 1, $size, $query);
+        $links['last'] = $this->generateCollectionUrl($type, $totalPages, $size, $query);
+
+        if ($number > 1) {
+            $links['prev'] = $this->generateCollectionUrl($type, max(1, $number - 1), $size, $query);
+        }
+
+        if ($number < $totalPages) {
+            $links['next'] = $this->generateCollectionUrl($type, min($totalPages, $number + 1), $size, $query);
+        }
+
+        return $links;
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     */
+    private function generateCollectionUrl(string $type, int $number, int $size, array $query): string
+    {
+        $query['page']['number'] = $number;
+        $query['page']['size'] = $size;
+        $query['type'] = $type;
+
+        return $this->urls->generate(
+            'jsonapi.collection',
+            $query,
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+    }
+}

--- a/src/Http/Request/PaginationConfig.php
+++ b/src/Http/Request/PaginationConfig.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Request;
+
+final class PaginationConfig
+{
+    public function __construct(
+        public int $defaultSize = 25,
+        public int $maxSize = 100,
+    ) {
+    }
+}

--- a/src/Http/Request/QueryParser.php
+++ b/src/Http/Request/QueryParser.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Request;
+
+use JsonApi\Symfony\Query\Criteria;
+use JsonApi\Symfony\Query\Pagination;
+use JsonApi\Symfony\Query\Sorting;
+use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+final class QueryParser
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly PaginationConfig $paginationConfig,
+        private readonly SortingWhitelist $sortingWhitelist,
+    ) {
+    }
+
+    public function parse(string $type, Request $request): Criteria
+    {
+        $pagination = $this->parsePagination($request);
+        $criteria = new Criteria($pagination);
+
+        $criteria->fields = $this->parseFields($request);
+        $criteria->include = $this->parseInclude($type, $request);
+        $criteria->sort = $this->parseSort($type, $request);
+
+        return $criteria;
+    }
+
+    private function parsePagination(Request $request): Pagination
+    {
+        $page = $request->query->all('page');
+        if (!is_array($page)) {
+            $page = $request->query->all()['page'] ?? [];
+            if (!is_array($page)) {
+                $page = [];
+            }
+        }
+
+        $number = $page['number'] ?? 1;
+        $size = $page['size'] ?? $this->paginationConfig->defaultSize;
+
+        $number = $this->toInt($number, 'page[number]');
+        $size = $this->toInt($size, 'page[size]');
+
+        if ($number < 1) {
+            throw new BadRequestHttpException('page[number] must be greater than or equal to 1.');
+        }
+
+        if ($size < 1 || $size > $this->paginationConfig->maxSize) {
+            throw new BadRequestHttpException(sprintf(
+                'page[size] must be between 1 and %d.',
+                $this->paginationConfig->maxSize
+            ));
+        }
+
+        return new Pagination($number, $size);
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function parseFields(Request $request): array
+    {
+        $query = $request->query->all();
+        $fields = [];
+
+        if (!isset($query['fields'])) {
+            return $fields;
+        }
+
+        if (!is_array($query['fields'])) {
+            throw new BadRequestHttpException('fields parameter must be an array keyed by resource type.');
+        }
+
+        /** @var array<string, mixed> $rawFields */
+        $rawFields = $query['fields'];
+
+        foreach ($rawFields as $resourceType => $list) {
+            if (!is_string($resourceType) || $resourceType === '') {
+                throw new BadRequestHttpException('fields parameter keys must be resource types.');
+            }
+
+            if (!is_string($list)) {
+                throw new BadRequestHttpException(sprintf('fields[%s] must be a comma separated string.', $resourceType));
+            }
+
+            $entries = array_values(array_filter(array_map('trim', explode(',', $list)), static fn (string $value): bool => $value !== ''));
+            if ($entries === []) {
+                $fields[$resourceType] = [];
+                continue;
+            }
+
+            $metadata = $this->requireResourceMetadata($resourceType);
+            $allowed = array_merge(array_keys($metadata->attributes), array_keys($metadata->relationships));
+            if ($metadata->exposeId) {
+                $allowed[] = 'id';
+            }
+
+            $unique = [];
+            foreach ($entries as $entry) {
+                if (!in_array($entry, $allowed, true)) {
+                    throw new BadRequestHttpException(sprintf('Unknown field "%s" for resource type "%s".', $entry, $resourceType));
+                }
+
+                if (!in_array($entry, $unique, true)) {
+                    $unique[] = $entry;
+                }
+            }
+
+            $fields[$resourceType] = $unique;
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseInclude(string $type, Request $request): array
+    {
+        $raw = $request->query->get('include');
+        if ($raw === null || $raw === '') {
+            return [];
+        }
+
+        if (!is_string($raw)) {
+            throw new BadRequestHttpException('include parameter must be a string.');
+        }
+
+        $paths = [];
+        foreach (array_map('trim', explode(',', $raw)) as $path) {
+            if ($path === '') {
+                continue;
+            }
+
+            $this->validateIncludePath($type, $path);
+
+            if (!in_array($path, $paths, true)) {
+                $paths[] = $path;
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * @return list<Sorting>
+     */
+    private function parseSort(string $type, Request $request): array
+    {
+        $raw = $request->query->get('sort');
+        if ($raw === null || $raw === '') {
+            return [];
+        }
+
+        if (!is_string($raw)) {
+            throw new BadRequestHttpException('sort parameter must be a string.');
+        }
+
+        $allowed = $this->sortingWhitelist->allowedFor($type);
+        $result = [];
+
+        foreach (array_map('trim', explode(',', $raw)) as $sortField) {
+            if ($sortField === '') {
+                continue;
+            }
+
+            $desc = str_starts_with($sortField, '-');
+            $field = ltrim($sortField, '-');
+
+            if (!in_array($field, $allowed, true)) {
+                throw new BadRequestHttpException(sprintf('Sorting by "%s" is not allowed for "%s".', $field, $type));
+            }
+
+            $result[] = new Sorting($field, $desc);
+        }
+
+        return $result;
+    }
+
+    private function validateIncludePath(string $rootType, string $path): void
+    {
+        $segments = explode('.', $path);
+        $currentType = $rootType;
+
+        foreach ($segments as $index => $segment) {
+            $metadata = $this->requireResourceMetadata($currentType);
+
+            if (!isset($metadata->relationships[$segment])) {
+                throw new BadRequestHttpException(sprintf('Unknown relationship "%s" on resource "%s".', $segment, $currentType));
+            }
+
+            $relationship = $metadata->relationships[$segment];
+            $targetType = $relationship->targetType;
+
+            if ($targetType === null && $relationship->targetClass !== null) {
+                $targetMetadata = $this->registry->getByClass($relationship->targetClass);
+                $targetType = $targetMetadata?->type;
+            }
+
+            if ($index < count($segments) - 1) {
+                if ($targetType === null) {
+                    throw new BadRequestHttpException(sprintf('Relationship "%s" on resource "%s" cannot be chained without a target type.', $segment, $currentType));
+                }
+
+                $currentType = $targetType;
+            }
+        }
+    }
+
+    private function requireResourceMetadata(string $type): ResourceMetadata
+    {
+        if (!$this->registry->hasType($type)) {
+            throw new BadRequestHttpException(sprintf('Unknown resource type "%s".', $type));
+        }
+
+        return $this->registry->getByType($type);
+    }
+
+    private function toInt(mixed $value, string $name): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (!is_string($value)) {
+            throw new BadRequestHttpException(sprintf('%s must be an integer.', $name));
+        }
+
+        if (!preg_match('/^-?\d+$/', $value)) {
+            throw new BadRequestHttpException(sprintf('%s must be an integer.', $name));
+        }
+
+        return (int) $value;
+    }
+}

--- a/src/Http/Request/SortingWhitelist.php
+++ b/src/Http/Request/SortingWhitelist.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Request;
+
+final class SortingWhitelist
+{
+    /**
+     * @param array<string, list<string>> $map
+     */
+    public function __construct(private array $map = [])
+    {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function allowedFor(string $type): array
+    {
+        $fields = $this->map[$type] ?? [];
+
+        return array_values($fields);
+    }
+}

--- a/src/Query/Criteria.php
+++ b/src/Query/Criteria.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Query;
+
+final class Criteria
+{
+    /**
+     * @var array<string, list<string>>
+     */
+    public array $fields = [];
+
+    /**
+     * @var list<string>
+     */
+    public array $include = [];
+
+    /**
+     * @var list<Sorting>
+     */
+    public array $sort = [];
+
+    public Pagination $pagination;
+
+    public function __construct(?Pagination $pagination = null)
+    {
+        $this->pagination = $pagination ?? new Pagination(1, 10);
+    }
+}

--- a/src/Query/Pagination.php
+++ b/src/Query/Pagination.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Query;
+
+final class Pagination
+{
+    public function __construct(
+        public int $number,
+        public int $size,
+    ) {
+    }
+}

--- a/src/Query/Sorting.php
+++ b/src/Query/Sorting.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Query;
+
+final class Sorting
+{
+    public function __construct(
+        public string $field,
+        public bool $desc,
+    ) {
+    }
+}

--- a/src/Resource/Metadata/AttributeMetadata.php
+++ b/src/Resource/Metadata/AttributeMetadata.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Resource\Metadata;
+
+final class AttributeMetadata
+{
+    public function __construct(
+        public string $name,
+        public ?string $propertyPath = null,
+        public bool $readable = true,
+    ) {
+    }
+}

--- a/src/Resource/Metadata/RelationshipMetadata.php
+++ b/src/Resource/Metadata/RelationshipMetadata.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Resource\Metadata;
+
+final class RelationshipMetadata
+{
+    public function __construct(
+        public string $name,
+        public bool $toMany = false,
+        public ?string $targetType = null,
+        public ?string $propertyPath = null,
+        public ?string $targetClass = null,
+    ) {
+    }
+}

--- a/src/Resource/Metadata/ResourceMetadata.php
+++ b/src/Resource/Metadata/ResourceMetadata.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Resource\Metadata;
+
+/**
+ * @psalm-type AttributeMap = array<string, AttributeMetadata>
+ * @psalm-type RelationshipMap = array<string, RelationshipMetadata>
+ */
+final class ResourceMetadata
+{
+    /**
+     * @param AttributeMap        $attributes
+     * @param RelationshipMap     $relationships
+     */
+    public function __construct(
+        public string $type,
+        public string $class,
+        public array $attributes,
+        public array $relationships,
+        public bool $exposeId = true,
+        public ?string $idPropertyPath = null,
+    ) {
+    }
+}

--- a/src/Resource/Registry/ResourceRegistry.php
+++ b/src/Resource/Registry/ResourceRegistry.php
@@ -4,28 +4,261 @@ declare(strict_types=1);
 
 namespace JsonApi\Symfony\Resource\Registry;
 
-use JsonApi\Symfony\Contract\Resource\ResourceMetadataInterface;
+use JsonApi\Symfony\Resource\Attribute\Attribute as AttributeAttribute;
+use JsonApi\Symfony\Resource\Attribute\Id;
+use JsonApi\Symfony\Resource\Attribute\JsonApiResource;
+use JsonApi\Symfony\Resource\Attribute\Relationship as RelationshipAttribute;
+use JsonApi\Symfony\Resource\Metadata\AttributeMetadata;
+use JsonApi\Symfony\Resource\Metadata\RelationshipMetadata;
+use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
+use LogicException;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionProperty;
+use ReflectionUnionType;
 
-/**
- * @internal Stage 0 placeholder.
- */
-class ResourceRegistry
+final class ResourceRegistry implements ResourceRegistryInterface
 {
     /**
-     * @var array<string, ResourceMetadataInterface>
+     * @var array<string, ResourceMetadata>
      */
-    private array $resources = [];
+    private array $metadataByType = [];
 
-    public function register(ResourceMetadataInterface $metadata): void
+    /**
+     * @var array<string, ResourceMetadata>
+     */
+    private array $metadataByClass = [];
+
+    /**
+     * @param iterable<object|string> $resources
+     */
+    public function __construct(iterable $resources)
     {
-        $this->resources[$metadata->getType()] = $metadata;
+        foreach ($resources as $type => $resource) {
+            $class = is_object($resource) ? $resource::class : (string) $resource;
+            $metadata = $this->buildMetadata($class);
+
+            if (is_string($type) && $type !== $metadata->type) {
+                throw new LogicException(sprintf(
+                    'Resource type mismatch for %s: expected "%s", got "%s".',
+                    $class,
+                    $type,
+                    $metadata->type
+                ));
+            }
+
+            if (isset($this->metadataByType[$metadata->type])) {
+                throw new LogicException(sprintf('Resource type "%s" is already registered.', $metadata->type));
+            }
+
+            $this->metadataByType[$metadata->type] = $metadata;
+            $this->metadataByClass[$metadata->class] = $metadata;
+        }
+    }
+
+    public function getByType(string $type): ResourceMetadata
+    {
+        if (!isset($this->metadataByType[$type])) {
+            throw new LogicException(sprintf('Unknown resource type "%s".', $type));
+        }
+
+        return $this->metadataByType[$type];
+    }
+
+    public function hasType(string $type): bool
+    {
+        return isset($this->metadataByType[$type]);
+    }
+
+    public function getByClass(string $class): ?ResourceMetadata
+    {
+        return $this->metadataByClass[$class] ?? null;
+    }
+
+    private function buildMetadata(string $class): ResourceMetadata
+    {
+        $reflection = new ReflectionClass($class);
+        $resourceAttributes = $reflection->getAttributes(JsonApiResource::class, ReflectionAttribute::IS_INSTANCEOF);
+
+        if ($resourceAttributes === []) {
+            throw new LogicException(sprintf('Class %s is not marked with #[JsonApiResource].', $class));
+        }
+
+        /** @var JsonApiResource $resource */
+        $resource = $resourceAttributes[0]->newInstance();
+
+        $attributes = [];
+        $relationships = [];
+        $idPropertyPath = null;
+
+        foreach ($reflection->getProperties() as $property) {
+            if ($this->hasAttribute($property, Id::class)) {
+                $idPropertyPath = $property->getName();
+            }
+
+            $attributes = $this->extractAttributes($attributes, $property, $property->getName());
+            $relationships = $this->extractRelationships($relationships, $property, $property->getName());
+        }
+
+        foreach ($reflection->getMethods() as $method) {
+            if ($method->isStatic()) {
+                continue;
+            }
+
+            $propertyPath = $this->guessPropertyPathFromMethod($method);
+            if ($this->hasAttribute($method, Id::class)) {
+                $idPropertyPath = $propertyPath;
+            }
+
+            $attributes = $this->extractAttributes($attributes, $method, $propertyPath);
+            $relationships = $this->extractRelationships($relationships, $method, $propertyPath);
+        }
+
+        return new ResourceMetadata(
+            $resource->type,
+            $class,
+            $attributes,
+            $relationships,
+            $resource->exposeId,
+            $idPropertyPath,
+        );
     }
 
     /**
-     * @return array<string, ResourceMetadataInterface>
+     * @template T of ReflectionMethod|ReflectionProperty
+     *
+     * @param array<string, AttributeMetadata> $attributes
+     * @param T                                $member
+     *
+     * @return array<string, AttributeMetadata>
      */
-    public function all(): array
+    private function extractAttributes(array $attributes, ReflectionProperty|ReflectionMethod $member, string $propertyPath): array
     {
-        return $this->resources;
+        foreach ($member->getAttributes(AttributeAttribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            /** @var AttributeAttribute $instance */
+            $instance = $attribute->newInstance();
+            $name = $instance->name ?? $this->guessName($member, $propertyPath);
+
+            if (isset($attributes[$name])) {
+                throw new LogicException(sprintf('Duplicate attribute "%s" detected on %s::%s.', $name, $member->getDeclaringClass()->getName(), $member->getName()));
+            }
+
+            $attributes[$name] = new AttributeMetadata($name, $propertyPath, $instance->readable);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @template T of ReflectionMethod|ReflectionProperty
+     *
+     * @param array<string, RelationshipMetadata> $relationships
+     * @param T                                   $member
+     *
+     * @return array<string, RelationshipMetadata>
+     */
+    private function extractRelationships(array $relationships, ReflectionProperty|ReflectionMethod $member, string $propertyPath): array
+    {
+        foreach ($member->getAttributes(RelationshipAttribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            /** @var RelationshipAttribute $instance */
+            $instance = $attribute->newInstance();
+            $name = $this->guessName($member, $propertyPath);
+
+            if (isset($relationships[$name])) {
+                throw new LogicException(sprintf('Duplicate relationship "%s" detected on %s::%s.', $name, $member->getDeclaringClass()->getName(), $member->getName()));
+            }
+
+            $targetClass = $this->guessTargetClass($member);
+            $relationships[$name] = new RelationshipMetadata(
+                $name,
+                $instance->toMany,
+                $this->guessTargetType($targetClass),
+                $propertyPath,
+                $targetClass,
+            );
+        }
+
+        return $relationships;
+    }
+
+    private function guessName(ReflectionProperty|ReflectionMethod $member, string $propertyPath): string
+    {
+        if ($member instanceof ReflectionProperty) {
+            return $propertyPath;
+        }
+
+        $method = $member->getName();
+        foreach (['get', 'is', 'has'] as $prefix) {
+            if (str_starts_with($method, $prefix) && strlen($method) > strlen($prefix)) {
+                return lcfirst(substr($method, strlen($prefix)));
+            }
+        }
+
+        return $propertyPath;
+    }
+
+    private function guessPropertyPathFromMethod(ReflectionMethod $method): string
+    {
+        $name = $method->getName();
+        foreach (['get', 'is', 'has'] as $prefix) {
+            if (str_starts_with($name, $prefix) && strlen($name) > strlen($prefix)) {
+                return lcfirst(substr($name, strlen($prefix)));
+            }
+        }
+
+        return $name;
+    }
+
+    private function hasAttribute(ReflectionProperty|ReflectionMethod $member, string $attribute): bool
+    {
+        return $member->getAttributes($attribute, ReflectionAttribute::IS_INSTANCEOF) !== [];
+    }
+
+    private function guessTargetClass(ReflectionProperty|ReflectionMethod $member): ?string
+    {
+        $type = $member instanceof ReflectionProperty ? $member->getType() : $member->getReturnType();
+
+        if ($type === null) {
+            return null;
+        }
+
+        if ($type instanceof ReflectionNamedType) {
+            return $type->isBuiltin() ? null : $type->getName();
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            foreach ($type->getTypes() as $inner) {
+                if (!$inner->isBuiltin()) {
+                    return $inner->getName();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function guessTargetType(?string $targetClass): ?string
+    {
+        if ($targetClass === null || !class_exists($targetClass)) {
+            return null;
+        }
+
+        if (isset($this->metadataByClass[$targetClass])) {
+            return $this->metadataByClass[$targetClass]->type;
+        }
+
+        $reflection = new ReflectionClass($targetClass);
+        $attributes = $reflection->getAttributes(JsonApiResource::class, ReflectionAttribute::IS_INSTANCEOF);
+
+        if ($attributes === []) {
+            return null;
+        }
+
+        /** @var JsonApiResource $attribute */
+        $attribute = $attributes[0]->newInstance();
+
+        return $attribute->type;
     }
 }

--- a/src/Resource/Registry/ResourceRegistryInterface.php
+++ b/src/Resource/Registry/ResourceRegistryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Resource\Registry;
+
+use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
+
+interface ResourceRegistryInterface
+{
+    public function getByType(string $type): ResourceMetadata;
+
+    public function hasType(string $type): bool;
+
+    public function getByClass(string $class): ?ResourceMetadata;
+}

--- a/tests/Fixtures/InMemory/InMemoryRepository.php
+++ b/tests/Fixtures/InMemory/InMemoryRepository.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Fixtures\InMemory;
+
+use DateInterval;
+use DateTimeImmutable;
+use JsonApi\Symfony\Contract\Data\ResourceIdentifier;
+use JsonApi\Symfony\Contract\Data\ResourceRepository;
+use JsonApi\Symfony\Contract\Data\Slice;
+use JsonApi\Symfony\Query\Criteria;
+use JsonApi\Symfony\Query\Sorting;
+use JsonApi\Symfony\Resource\Metadata\AttributeMetadata;
+use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use JsonApi\Symfony\Tests\Fixtures\Model\Article;
+use JsonApi\Symfony\Tests\Fixtures\Model\Author;
+use JsonApi\Symfony\Tests\Fixtures\Model\Tag;
+use RuntimeException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+final class InMemoryRepository implements ResourceRepository
+{
+    private PropertyAccessorInterface $accessor;
+
+    /**
+     * @var array<string, list<object>>
+     */
+    private array $data = [];
+
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        ?PropertyAccessorInterface $accessor = null,
+    ) {
+        $this->accessor = $accessor ?? PropertyAccess::createPropertyAccessor();
+        $this->seed();
+    }
+
+    public function findCollection(string $type, Criteria $criteria): Slice
+    {
+        $items = $this->data[$type] ?? [];
+        $items = $this->applySort($type, $items, $criteria->sort);
+
+        $total = count($items);
+        $size = $criteria->pagination->size;
+        $number = $criteria->pagination->number;
+        $offset = max(0, ($number - 1) * $size);
+
+        $items = array_slice($items, $offset, $size);
+
+        return new Slice(array_values($items), $number, $size, $total);
+    }
+
+    public function findOne(string $type, string $id, Criteria $criteria): ?object
+    {
+        return $this->findModel($type, $id);
+    }
+
+    public function findRelated(string $type, string $relationship, array $identifiers): iterable
+    {
+        $results = [];
+
+        foreach ($identifiers as $identifier) {
+            $model = $this->findModel($identifier->type, $identifier->id);
+            if ($model !== null) {
+                $results[] = $model;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param list<object> $items
+     * @param list<Sorting> $sorting
+     *
+     * @return list<object>
+     */
+    private function applySort(string $type, array $items, array $sorting): array
+    {
+        if ($sorting === []) {
+            return $items;
+        }
+
+        $metadata = $this->registry->getByType($type);
+
+        usort($items, function (object $a, object $b) use ($sorting, $metadata): int {
+            foreach ($sorting as $sort) {
+                $result = $this->compare($metadata, $a, $b, $sort);
+                if ($result !== 0) {
+                    return $sort->desc ? -$result : $result;
+                }
+            }
+
+            return 0;
+        });
+
+        return $items;
+    }
+
+    private function compare(ResourceMetadata $metadata, object $a, object $b, Sorting $sorting): int
+    {
+        $path = $this->propertyPathForSort($metadata, $sorting->field);
+
+        $left = $this->accessor->getValue($a, $path);
+        $right = $this->accessor->getValue($b, $path);
+
+        $left = $this->normalizeSortable($left);
+        $right = $this->normalizeSortable($right);
+
+        return $left <=> $right;
+    }
+
+    private function propertyPathForSort(ResourceMetadata $metadata, string $field): string
+    {
+        if ($field === 'id') {
+            return $metadata->idPropertyPath ?? 'id';
+        }
+
+        if (isset($metadata->attributes[$field])) {
+            /** @var AttributeMetadata $attribute */
+            $attribute = $metadata->attributes[$field];
+
+            return $attribute->propertyPath ?? $field;
+        }
+
+        throw new RuntimeException(sprintf('Unknown sorting field "%s" for %s.', $field, $metadata->type));
+    }
+
+    private function normalizeSortable(mixed $value): mixed
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->getTimestamp();
+        }
+
+        if ($value instanceof \Stringable) {
+            return (string) $value;
+        }
+
+        return $value;
+    }
+
+    private function seed(): void
+    {
+        $authors = [
+            new Author('1', 'Alice'),
+            new Author('2', 'Bob'),
+            new Author('3', 'Carol'),
+        ];
+
+        $tags = [
+            new Tag('1', 'php'),
+            new Tag('2', 'symfony'),
+            new Tag('3', 'jsonapi'),
+            new Tag('4', 'dx'),
+            new Tag('5', 'rest'),
+        ];
+
+        $articles = [];
+        $date = new DateTimeImmutable('2024-01-01T10:00:00Z');
+        for ($i = 1; $i <= 15; ++$i) {
+            $author = $authors[($i - 1) % count($authors)];
+            $articleTags = [$tags[($i - 1) % count($tags)], $tags[$i % count($tags)]];
+            $articles[] = new Article((string) $i, sprintf('Article %02d', $i), $date, $author, ...$articleTags);
+            $date = $date->add(new DateInterval('P1D'));
+        }
+
+        $this->data = [
+            'articles' => $articles,
+            'authors' => $authors,
+            'tags' => $tags,
+        ];
+    }
+
+    private function findModel(string $type, string $id): ?object
+    {
+        if (!isset($this->data[$type])) {
+            return null;
+        }
+
+        $metadata = $this->registry->getByType($type);
+        $path = $metadata->idPropertyPath ?? 'id';
+
+        foreach ($this->data[$type] as $model) {
+            $value = $this->accessor->getValue($model, $path);
+            if ((string) $value === $id) {
+                return $model;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Fixtures/Model/Article.php
+++ b/tests/Fixtures/Model/Article.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Fixtures\Model;
+
+use DateTimeImmutable;
+use JsonApi\Symfony\Resource\Attribute\Attribute;
+use JsonApi\Symfony\Resource\Attribute\Id;
+use JsonApi\Symfony\Resource\Attribute\JsonApiResource;
+use JsonApi\Symfony\Resource\Attribute\Relationship;
+
+#[JsonApiResource(type: 'articles')]
+final class Article
+{
+    /** @var list<Tag> */
+    private array $tags = [];
+
+    public function __construct(
+        #[Id]
+        #[Attribute]
+        public string $id,
+        #[Attribute]
+        public string $title,
+        private DateTimeImmutable $createdAt,
+        private Author $author,
+        Tag ...$tags,
+    ) {
+        $this->tags = $tags === [] ? [] : array_values($tags);
+    }
+
+    #[Attribute(name: 'createdAt')]
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    #[Relationship]
+    public function getAuthor(): Author
+    {
+        return $this->author;
+    }
+
+    /**
+     * @return list<Tag>
+     */
+    #[Relationship(toMany: true)]
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+}

--- a/tests/Fixtures/Model/Author.php
+++ b/tests/Fixtures/Model/Author.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Fixtures\Model;
+
+use JsonApi\Symfony\Resource\Attribute\Attribute;
+use JsonApi\Symfony\Resource\Attribute\Id;
+use JsonApi\Symfony\Resource\Attribute\JsonApiResource;
+
+#[JsonApiResource(type: 'authors')]
+final class Author
+{
+    #[Id]
+    #[Attribute]
+    public string $id;
+
+    #[Attribute]
+    public string $name;
+
+    public function __construct(string $id, string $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+}

--- a/tests/Fixtures/Model/Tag.php
+++ b/tests/Fixtures/Model/Tag.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Fixtures\Model;
+
+use JsonApi\Symfony\Resource\Attribute\Attribute;
+use JsonApi\Symfony\Resource\Attribute\Id;
+use JsonApi\Symfony\Resource\Attribute\JsonApiResource;
+
+#[JsonApiResource(type: 'tags')]
+final class Tag
+{
+    #[Id]
+    #[Attribute]
+    public string $id;
+
+    #[Attribute]
+    public string $name;
+
+    public function __construct(string $id, string $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+}

--- a/tests/Functional/CollectionGetTest.php
+++ b/tests/Functional/CollectionGetTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CollectionGetTest extends JsonApiTestCase
+{
+    public function testCollectionReturnsDocument(): void
+    {
+        $request = Request::create('/api/articles', 'GET');
+        $response = ($this->collectionController())($request, 'articles');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
+
+        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('data', $document);
+        self::assertCount(15, $document['data']);
+        self::assertSame('http://localhost/api/articles', $document['links']['self']);
+        self::assertSame(15, $document['meta']['total']);
+        self::assertSame(1, $document['meta']['page']);
+        self::assertSame(25, $document['meta']['size']);
+        self::assertNotEmpty($document['links']['first']);
+        self::assertNotEmpty($document['links']['last']);
+    }
+}

--- a/tests/Functional/ErrorsTest.php
+++ b/tests/Functional/ErrorsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class ErrorsTest extends JsonApiTestCase
+{
+    public function testUnknownTypeResultsIn404(): void
+    {
+        $request = Request::create('/api/unknown', 'GET');
+
+        $this->expectException(NotFoundHttpException::class);
+
+        ($this->collectionController())($request, 'unknown');
+    }
+
+    public function testUnknownFieldResultsIn400(): void
+    {
+        $request = Request::create('/api/articles', 'GET', ['fields' => ['articles' => 'unknown']]);
+
+        $this->expectException(BadRequestHttpException::class);
+
+        ($this->collectionController())($request, 'articles');
+    }
+
+    public function testInvalidIncludeResultsIn400(): void
+    {
+        $request = Request::create('/api/articles', 'GET', ['include' => 'unknown']);
+
+        $this->expectException(BadRequestHttpException::class);
+
+        ($this->collectionController())($request, 'articles');
+    }
+}

--- a/tests/Functional/FieldsTest.php
+++ b/tests/Functional/FieldsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class FieldsTest extends JsonApiTestCase
+{
+    public function testSparseFieldsetOnResource(): void
+    {
+        $request = Request::create('/api/articles/1', 'GET', ['fields' => ['articles' => 'title']]);
+        $response = ($this->resourceController())($request, 'articles', '1');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(['title'], array_keys($document['data']['attributes']));
+    }
+}

--- a/tests/Functional/IncludeTest.php
+++ b/tests/Functional/IncludeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class IncludeTest extends JsonApiTestCase
+{
+    public function testIncludeAddsRelatedResources(): void
+    {
+        $request = Request::create('/api/articles/1', 'GET', ['include' => 'author,tags']);
+        $response = ($this->resourceController())($request, 'articles', '1');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('included', $document);
+        self::assertCount(3, $document['included']);
+
+        $types = array_column($document['included'], 'type');
+        self::assertContains('authors', $types);
+        self::assertContains('tags', $types);
+    }
+}

--- a/tests/Functional/JsonApiTestCase.php
+++ b/tests/Functional/JsonApiTestCase.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional;
+
+use JsonApi\Symfony\Contract\Data\ResourceRepository;
+use JsonApi\Symfony\Http\Controller\CollectionController;
+use JsonApi\Symfony\Http\Controller\ResourceController;
+use JsonApi\Symfony\Http\Document\DocumentBuilder;
+use JsonApi\Symfony\Http\Link\LinkGenerator;
+use JsonApi\Symfony\Http\Request\PaginationConfig;
+use JsonApi\Symfony\Http\Request\QueryParser;
+use JsonApi\Symfony\Http\Request\SortingWhitelist;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistry;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use JsonApi\Symfony\Tests\Fixtures\InMemory\InMemoryRepository;
+use JsonApi\Symfony\Tests\Fixtures\Model\Article;
+use JsonApi\Symfony\Tests\Fixtures\Model\Author;
+use JsonApi\Symfony\Tests\Fixtures\Model\Tag;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+abstract class JsonApiTestCase extends TestCase
+{
+    private ?ResourceRegistryInterface $registry = null;
+    private ?ResourceRepository $repository = null;
+    private ?QueryParser $parser = null;
+    private ?DocumentBuilder $document = null;
+    private ?CollectionController $collectionController = null;
+    private ?ResourceController $resourceController = null;
+    private ?PropertyAccessorInterface $accessor = null;
+
+    protected function collectionController(): CollectionController
+    {
+        $this->boot();
+
+        return $this->collectionController;
+    }
+
+    protected function resourceController(): ResourceController
+    {
+        $this->boot();
+
+        return $this->resourceController;
+    }
+
+    protected function registry(): ResourceRegistryInterface
+    {
+        $this->boot();
+
+        return $this->registry;
+    }
+
+    protected function repository(): ResourceRepository
+    {
+        $this->boot();
+
+        return $this->repository;
+    }
+
+    protected function parser(): QueryParser
+    {
+        $this->boot();
+
+        return $this->parser;
+    }
+
+    protected function documentBuilder(): DocumentBuilder
+    {
+        $this->boot();
+
+        return $this->document;
+    }
+
+    protected function propertyAccessor(): PropertyAccessorInterface
+    {
+        $this->boot();
+
+        return $this->accessor;
+    }
+
+    private function boot(): void
+    {
+        if ($this->collectionController !== null) {
+            return;
+        }
+
+        $registry = new ResourceRegistry([
+            Article::class,
+            Author::class,
+            Tag::class,
+        ]);
+
+        $pagination = new PaginationConfig(defaultSize: 25, maxSize: 100);
+        $sorting = new SortingWhitelist([
+            'articles' => ['title', 'createdAt'],
+            'authors' => ['name'],
+            'tags' => ['name'],
+        ]);
+
+        $parser = new QueryParser($registry, $pagination, $sorting);
+
+        $routes = new RouteCollection();
+        $routes->add('jsonapi.collection', new Route('/api/{type}'));
+        $routes->add('jsonapi.resource', new Route('/api/{type}/{id}'));
+
+        $context = new RequestContext();
+        $context->setScheme('http');
+        $context->setHost('localhost');
+
+        $urlGenerator = new UrlGenerator($routes, $context);
+        $accessor = PropertyAccess::createPropertyAccessor();
+        $document = new DocumentBuilder($registry, $accessor, new LinkGenerator($urlGenerator));
+        $repository = new InMemoryRepository($registry, $accessor);
+
+        $this->registry = $registry;
+        $this->repository = $repository;
+        $this->parser = $parser;
+        $this->document = $document;
+        $this->collectionController = new CollectionController($registry, $repository, $parser, $document);
+        $this->resourceController = new ResourceController($registry, $repository, $parser, $document);
+        $this->accessor = $accessor;
+    }
+}

--- a/tests/Functional/ResourceGetTest.php
+++ b/tests/Functional/ResourceGetTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResourceGetTest extends JsonApiTestCase
+{
+    public function testSingleResourceResponse(): void
+    {
+        $request = Request::create('/api/articles/1', 'GET');
+        $response = ($this->resourceController())($request, 'articles', '1');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
+
+        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('articles', $document['data']['type']);
+        self::assertSame('1', $document['data']['id']);
+        self::assertArrayHasKey('title', $document['data']['attributes']);
+        self::assertArrayHasKey('createdAt', $document['data']['attributes']);
+        self::assertSame('http://localhost/api/articles/1', $document['data']['links']['self']);
+        self::assertSame('http://localhost/api/articles/1', $document['links']['self']);
+    }
+}

--- a/tests/Functional/SortAndPageTest.php
+++ b/tests/Functional/SortAndPageTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SortAndPageTest extends JsonApiTestCase
+{
+    public function testPaginationAndSorting(): void
+    {
+        $request = Request::create('/api/articles', 'GET', [
+            'page' => ['number' => 2, 'size' => 5],
+            'sort' => '-createdAt',
+        ]);
+
+        $response = ($this->collectionController())($request, 'articles');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertCount(5, $document['data']);
+        self::assertSame('10', $document['data'][0]['id']);
+        self::assertSame('6', $document['data'][4]['id']);
+        $expectedFirst = 'http://localhost/api/articles?page%5Bnumber%5D=1&page%5Bsize%5D=5&sort=-createdAt';
+        $expectedLast = 'http://localhost/api/articles?page%5Bnumber%5D=3&page%5Bsize%5D=5&sort=-createdAt';
+        self::assertSame($expectedFirst, $document['links']['first']);
+        self::assertSame($expectedLast, $document['links']['last']);
+        self::assertSame($expectedFirst, $document['links']['prev']);
+        self::assertSame($expectedLast, $document['links']['next']);
+    }
+}

--- a/tests/Util/JsonApiResponseAsserts.php
+++ b/tests/Util/JsonApiResponseAsserts.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Util;
+
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+trait JsonApiResponseAsserts
+{
+    /**
+     * @return array<string, mixed>
+     */
+    protected function decode(JsonResponse $response): array
+    {
+        Assert::assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
+
+        return json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
## Summary
- build resource metadata registry and query parsing for include, sparse fieldsets, sorting, and pagination
- render collection and resource documents with link generation via new controllers and document builder
- add in-memory fixtures plus functional tests covering success paths and validation failures

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e2ca216b60832fa3642dbbed1266ec