### PR TITLE
Add JSON:API resource write support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: test stan cs-fix rector
 
 test:
-vendor/bin/phpunit
+	vendor/bin/phpunit
 
 stan:
-vendor/bin/phpstan analyse
+	vendor/bin/phpstan analyse
 
 cs-fix:
-vendor/bin/php-cs-fixer fix
+	vendor/bin/php-cs-fixer fix
 
 rector:
-vendor/bin/rector process
+	vendor/bin/rector process

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "symfony/event-dispatcher": "^7.1",
     "symfony/http-foundation": "^7.1",
     "symfony/routing": "^7.1",
-    "symfony/property-access": "^7.1"
+    "symfony/property-access": "^7.1",
+    "symfony/uid": "^7.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^11.0",

--- a/config/services.php
+++ b/config/services.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 use JsonApi\Symfony\Bridge\Symfony\EventSubscriber\ContentNegotiationSubscriber;
 use JsonApi\Symfony\Http\Controller\CollectionController;
+use JsonApi\Symfony\Http\Controller\CreateResourceController;
+use JsonApi\Symfony\Http\Controller\DeleteResourceController;
 use JsonApi\Symfony\Http\Controller\ResourceController;
+use JsonApi\Symfony\Http\Controller\UpdateResourceController;
 use JsonApi\Symfony\Http\Document\DocumentBuilder;
 use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
 use JsonApi\Symfony\Http\Link\LinkGenerator;
 use JsonApi\Symfony\Http\Request\PaginationConfig;
 use JsonApi\Symfony\Http\Request\QueryParser;
 use JsonApi\Symfony\Http\Request\SortingWhitelist;
+use JsonApi\Symfony\Http\Write\ChangeSetFactory;
+use JsonApi\Symfony\Http\Write\InputDocumentValidator;
+use JsonApi\Symfony\Http\Write\WriteConfig;
 use JsonApi\Symfony\Resource\Registry\ResourceRegistry;
 use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -89,6 +95,29 @@ return static function (ContainerConfigurator $configurator): void {
     ;
 
     $services
+        ->set(WriteConfig::class)
+        ->args([
+            '%jsonapi.write.allow_relationship_writes%',
+            '%jsonapi.write.client_generated_ids%',
+        ])
+    ;
+
+    $services
+        ->set(InputDocumentValidator::class)
+        ->args([
+            service(ResourceRegistryInterface::class),
+            service(WriteConfig::class),
+        ])
+    ;
+
+    $services
+        ->set(ChangeSetFactory::class)
+        ->args([
+            service(ResourceRegistryInterface::class),
+        ])
+    ;
+
+    $services
         ->set(CollectionController::class)
         ->autowire()
         ->autoconfigure()
@@ -97,6 +126,27 @@ return static function (ContainerConfigurator $configurator): void {
 
     $services
         ->set(ResourceController::class)
+        ->autowire()
+        ->autoconfigure()
+        ->tag('controller.service_arguments')
+    ;
+
+    $services
+        ->set(CreateResourceController::class)
+        ->autowire()
+        ->autoconfigure()
+        ->tag('controller.service_arguments')
+    ;
+
+    $services
+        ->set(UpdateResourceController::class)
+        ->autowire()
+        ->autoconfigure()
+        ->tag('controller.service_arguments')
+    ;
+
+    $services
+        ->set(DeleteResourceController::class)
         ->autowire()
         ->autoconfigure()
         ->tag('controller.service_arguments')

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -55,6 +55,18 @@ final class Configuration implements ConfigurationInterface
             ->end()
         ;
 
+        $children->arrayNode('write')
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->booleanNode('allow_relationship_writes')->defaultFalse()->end()
+                ->arrayNode('client_generated_ids')
+                    ->useAttributeAsKey('type')
+                    ->booleanPrototype()->end()
+                    ->defaultValue([])
+                ->end()
+            ->end()
+        ;
+
         return $treeBuilder;
     }
 }

--- a/src/Bridge/Symfony/DependencyInjection/JsonApiExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/JsonApiExtension.php
@@ -24,6 +24,8 @@ final class JsonApiExtension extends Extension
         $container->setParameter('jsonapi.pagination.default_size', $config['pagination']['default_size']);
         $container->setParameter('jsonapi.pagination.max_size', $config['pagination']['max_size']);
         $container->setParameter('jsonapi.sorting.whitelist', $config['sorting']['whitelist']);
+        $container->setParameter('jsonapi.write.allow_relationship_writes', $config['write']['allow_relationship_writes']);
+        $container->setParameter('jsonapi.write.client_generated_ids', $config['write']['client_generated_ids']);
 
         $this->registerAutoconfiguration($container);
 

--- a/src/Contract/Data/ChangeSet.php
+++ b/src/Contract/Data/ChangeSet.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Data;
+
+final class ChangeSet
+{
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function __construct(public array $attributes = [])
+    {
+    }
+}

--- a/src/Contract/Data/ResourcePersister.php
+++ b/src/Contract/Data/ResourcePersister.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Data;
+
+use JsonApi\Symfony\Http\Exception\ConflictException;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+
+interface ResourcePersister
+{
+    /**
+     * @throws ConflictException
+     */
+    public function create(string $type, ChangeSet $changes, ?string $clientId = null): object;
+
+    /**
+     * @throws NotFoundException
+     */
+    public function update(string $type, string $id, ChangeSet $changes): object;
+
+    /**
+     * @throws NotFoundException
+     */
+    public function delete(string $type, string $id): void;
+}

--- a/src/Contract/Tx/TransactionManager.php
+++ b/src/Contract/Tx/TransactionManager.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Tx;
+
+interface TransactionManager
+{
+    /**
+     * @template T
+     *
+     * @param callable():T $callback
+     *
+     * @return T
+     */
+    public function transactional(callable $callback);
+}

--- a/src/Http/Controller/CreateResourceController.php
+++ b/src/Http/Controller/CreateResourceController.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Controller;
+
+use JsonApi\Symfony\Contract\Data\ResourcePersister;
+use JsonApi\Symfony\Contract\Tx\TransactionManager;
+use JsonApi\Symfony\Http\Document\DocumentBuilder;
+use JsonApi\Symfony\Http\Exception\BadRequestException;
+use JsonApi\Symfony\Http\Exception\ForbiddenException;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
+use JsonApi\Symfony\Http\Negotiation\MediaType;
+use JsonApi\Symfony\Http\Write\ChangeSetFactory;
+use JsonApi\Symfony\Http\Write\InputDocumentValidator;
+use JsonApi\Symfony\Http\Write\WriteConfig;
+use JsonApi\Symfony\Http\Link\LinkGenerator;
+use JsonApi\Symfony\Query\Criteria;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/api/{type}', methods: ['POST'], name: 'jsonapi.create')]
+final class CreateResourceController
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly InputDocumentValidator $validator,
+        private readonly ChangeSetFactory $changes,
+        private readonly ResourcePersister $persister,
+        private readonly TransactionManager $transaction,
+        private readonly DocumentBuilder $document,
+        private readonly LinkGenerator $links,
+        private readonly WriteConfig $writeConfig,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $type): Response
+    {
+        if (!$this->registry->hasType($type)) {
+            throw new NotFoundException(sprintf('Resource type "%s" not found.', $type));
+        }
+
+        $payload = $this->decode($request);
+        $input = $this->validator->validateAndExtract($type, null, $payload, 'POST');
+
+        $clientId = $input['id'];
+        if ($clientId !== null && !$this->writeConfig->allowClientId($type)) {
+            throw new ForbiddenException(sprintf('Client-generated IDs are not allowed for type "%s".', $type));
+        }
+
+        $model = $this->transaction->transactional(function () use ($type, $input) {
+            $changes = $this->changes->fromAttributes($type, $input['attributes']);
+
+            return $this->persister->create($type, $changes, $input['id']);
+        });
+
+        $document = $this->document->buildResource($type, $model, new Criteria(), $request);
+        $self = $document['data']['links']['self'] ?? $this->links->resourceSelf($type, $document['data']['id']);
+
+        return new JsonResponse(
+            $document,
+            Response::HTTP_CREATED,
+            [
+                'Content-Type' => MediaType::JSON_API,
+                'Location' => $self,
+            ]
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(Request $request): array
+    {
+        $contentType = $request->headers->get('Content-Type');
+        if ($contentType !== null && MediaType::JSON_API !== $this->normalizeMediaType($contentType)) {
+            throw JsonApiHttpException::unsupportedMediaType('JSON:API requires the "application/vnd.api+json" media type.');
+        }
+
+        $content = $request->getContent();
+
+        if ($content === '' || $content === false) {
+            throw new BadRequestException('Request body must not be empty.');
+        }
+
+        $decoded = json_decode($content, true);
+        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+            throw new BadRequestException(sprintf('Malformed JSON: %s.', json_last_error_msg()));
+        }
+
+        if (!is_array($decoded)) {
+            throw new BadRequestException('Request body must be a valid JSON object.');
+        }
+
+        return $decoded;
+    }
+
+    private function normalizeMediaType(string $value): string
+    {
+        $normalized = trim(strtolower($value));
+        $semicolonPosition = strpos($normalized, ';');
+
+        if ($semicolonPosition === false) {
+            return $normalized;
+        }
+
+        return substr($normalized, 0, $semicolonPosition);
+    }
+}

--- a/src/Http/Controller/DeleteResourceController.php
+++ b/src/Http/Controller/DeleteResourceController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Controller;
+
+use JsonApi\Symfony\Contract\Data\ResourcePersister;
+use JsonApi\Symfony\Contract\Tx\TransactionManager;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/api/{type}/{id}', methods: ['DELETE'], name: 'jsonapi.delete')]
+final class DeleteResourceController
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly ResourcePersister $persister,
+        private readonly TransactionManager $transaction,
+    ) {
+    }
+
+    public function __invoke(string $type, string $id): Response
+    {
+        if (!$this->registry->hasType($type)) {
+            throw new NotFoundException(sprintf('Resource type "%s" not found.', $type));
+        }
+
+        $this->transaction->transactional(function () use ($type, $id): void {
+            $this->persister->delete($type, $id);
+        });
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Http/Controller/UpdateResourceController.php
+++ b/src/Http/Controller/UpdateResourceController.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Controller;
+
+use JsonApi\Symfony\Contract\Data\ResourcePersister;
+use JsonApi\Symfony\Contract\Tx\TransactionManager;
+use JsonApi\Symfony\Http\Document\DocumentBuilder;
+use JsonApi\Symfony\Http\Exception\BadRequestException;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
+use JsonApi\Symfony\Http\Negotiation\MediaType;
+use JsonApi\Symfony\Http\Write\ChangeSetFactory;
+use JsonApi\Symfony\Http\Write\InputDocumentValidator;
+use JsonApi\Symfony\Query\Criteria;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/api/{type}/{id}', methods: ['PATCH'], name: 'jsonapi.update')]
+final class UpdateResourceController
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly InputDocumentValidator $validator,
+        private readonly ChangeSetFactory $changes,
+        private readonly ResourcePersister $persister,
+        private readonly TransactionManager $transaction,
+        private readonly DocumentBuilder $document,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $type, string $id): Response
+    {
+        if (!$this->registry->hasType($type)) {
+            throw new NotFoundException(sprintf('Resource type "%s" not found.', $type));
+        }
+
+        $payload = $this->decode($request);
+        $input = $this->validator->validateAndExtract($type, $id, $payload, 'PATCH');
+
+        $model = $this->transaction->transactional(function () use ($type, $id, $input) {
+            $changes = $this->changes->fromAttributes($type, $input['attributes']);
+
+            return $this->persister->update($type, $id, $changes);
+        });
+
+        $document = $this->document->buildResource($type, $model, new Criteria(), $request);
+
+        return new JsonResponse($document, Response::HTTP_OK, ['Content-Type' => MediaType::JSON_API]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(Request $request): array
+    {
+        $contentType = $request->headers->get('Content-Type');
+        if ($contentType !== null && MediaType::JSON_API !== $this->normalizeMediaType($contentType)) {
+            throw JsonApiHttpException::unsupportedMediaType('JSON:API requires the "application/vnd.api+json" media type.');
+        }
+
+        $content = $request->getContent();
+
+        if ($content === '' || $content === false) {
+            throw new BadRequestException('Request body must not be empty.');
+        }
+
+        $decoded = json_decode($content, true);
+        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+            throw new BadRequestException(sprintf('Malformed JSON: %s.', json_last_error_msg()));
+        }
+
+        if (!is_array($decoded)) {
+            throw new BadRequestException('Request body must be a valid JSON object.');
+        }
+
+        return $decoded;
+    }
+
+    private function normalizeMediaType(string $value): string
+    {
+        $normalized = trim(strtolower($value));
+        $semicolonPosition = strpos($normalized, ';');
+
+        if ($semicolonPosition === false) {
+            return $normalized;
+        }
+
+        return substr($normalized, 0, $semicolonPosition);
+    }
+}

--- a/src/Http/Exception/BadRequestException.php
+++ b/src/Http/Exception/BadRequestException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class BadRequestException extends HttpException
+{
+    public function __construct(string $message = 'Bad Request')
+    {
+        parent::__construct(400, $message);
+    }
+}

--- a/src/Http/Exception/ConflictException.php
+++ b/src/Http/Exception/ConflictException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ConflictException extends HttpException
+{
+    public function __construct(string $message = 'Conflict')
+    {
+        parent::__construct(409, $message);
+    }
+}

--- a/src/Http/Exception/ForbiddenException.php
+++ b/src/Http/Exception/ForbiddenException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ForbiddenException extends HttpException
+{
+    public function __construct(string $message = 'Forbidden')
+    {
+        parent::__construct(403, $message);
+    }
+}

--- a/src/Http/Exception/NotFoundException.php
+++ b/src/Http/Exception/NotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class NotFoundException extends HttpException
+{
+    public function __construct(string $message = 'Not Found')
+    {
+        parent::__construct(404, $message);
+    }
+}

--- a/src/Http/Write/ChangeSetFactory.php
+++ b/src/Http/Write/ChangeSetFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Write;
+
+use JsonApi\Symfony\Contract\Data\ChangeSet;
+use JsonApi\Symfony\Http\Exception\BadRequestException;
+use JsonApi\Symfony\Resource\Metadata\AttributeMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+
+final class ChangeSetFactory
+{
+    public function __construct(private readonly ResourceRegistryInterface $registry)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function fromAttributes(string $type, array $attributes): ChangeSet
+    {
+        $metadata = $this->registry->getByType($type);
+        $mapped = [];
+
+        foreach ($attributes as $name => $value) {
+            if (!isset($metadata->attributes[$name])) {
+                throw new BadRequestException(sprintf('Unknown attribute "%s" for type "%s".', $name, $type));
+            }
+
+            /** @var AttributeMetadata $attribute */
+            $attribute = $metadata->attributes[$name];
+            $path = $attribute->propertyPath ?? $name;
+            $mapped[$path] = $value;
+        }
+
+        return new ChangeSet($mapped);
+    }
+}

--- a/src/Http/Write/InputDocumentValidator.php
+++ b/src/Http/Write/InputDocumentValidator.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Write;
+
+use JsonApi\Symfony\Http\Exception\BadRequestException;
+use JsonApi\Symfony\Http\Exception\ConflictException;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Resource\Metadata\AttributeMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+
+final class InputDocumentValidator
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly WriteConfig $config,
+    ) {
+    }
+
+    /**
+     * @return array{type: string, id: ?string, attributes: array<string, mixed>, relationships: array<string, mixed>}
+     */
+    public function validateAndExtract(string $routeType, ?string $routeId, array $payload, string $method): array
+    {
+        if (!$this->registry->hasType($routeType)) {
+            throw new NotFoundException(sprintf('Resource type "%s" not found.', $routeType));
+        }
+
+        if (!isset($payload['data'])) {
+            throw new BadRequestException('Document must contain a "data" member.');
+        }
+
+        if (!is_array($payload['data'])) {
+            throw new BadRequestException('The "data" member must be an object.');
+        }
+
+        /** @var array<string, mixed> $data */
+        $data = $payload['data'];
+
+        $type = $data['type'] ?? null;
+        if (!is_string($type) || $type === '') {
+            throw new BadRequestException('Resource type must be a non-empty string.');
+        }
+
+        if ($type !== $routeType) {
+            throw new ConflictException('Resource type does not match the endpoint.');
+        }
+
+        $id = null;
+        if (array_key_exists('id', $data)) {
+            if (!is_string($data['id']) || $data['id'] === '') {
+                throw new BadRequestException('Resource id must be a non-empty string.');
+            }
+
+            $id = $data['id'];
+        }
+
+        if ($method === 'PATCH') {
+            if ($id === null) {
+                throw new ConflictException('PATCH requests require a resource id.');
+            }
+
+            if ($routeId === null || $id !== $routeId) {
+                throw new ConflictException('Resource id does not match the endpoint.');
+            }
+        }
+
+        $relationships = [];
+        if (array_key_exists('relationships', $data)) {
+            if (!is_array($data['relationships'])) {
+                throw new BadRequestException('The "relationships" member must be an object.');
+            }
+
+            /** @var array<string, mixed> $relationships */
+            $relationships = $data['relationships'];
+
+            if ($relationships !== [] && !$this->config->allowRelationshipWrites) {
+                throw new BadRequestException('Writing relationships is not allowed.');
+            }
+
+            if ($relationships !== [] && array_is_list($relationships)) {
+                throw new BadRequestException('The "relationships" member must be an object.');
+            }
+        }
+
+        $attributes = [];
+        if (array_key_exists('attributes', $data)) {
+            if (!is_array($data['attributes'])) {
+                throw new BadRequestException('The "attributes" member must be an object.');
+            }
+
+            /** @var array<string, mixed> $attributes */
+            $attributes = $data['attributes'];
+        }
+
+        if ($attributes !== [] && array_is_list($attributes)) {
+            throw new BadRequestException('The "attributes" member must be an object.');
+        }
+
+        $metadata = $this->registry->getByType($routeType);
+
+        foreach ($attributes as $name => $_) {
+            if (!isset($metadata->attributes[$name])) {
+                throw new BadRequestException(sprintf('Unknown attribute "%s" for type "%s".', $name, $routeType));
+            }
+
+            /** @var AttributeMetadata $attribute */
+            $attribute = $metadata->attributes[$name];
+            if (!$attribute->writable) {
+                throw new BadRequestException(sprintf('Attribute "%s" is read-only.', $name));
+            }
+        }
+
+        return [
+            'type' => $type,
+            'id' => $id,
+            'attributes' => $attributes,
+            'relationships' => $relationships,
+        ];
+    }
+}

--- a/src/Http/Write/WriteConfig.php
+++ b/src/Http/Write/WriteConfig.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Write;
+
+final class WriteConfig
+{
+    /**
+     * @param array<string, bool> $clientIdAllowed
+     */
+    public function __construct(
+        public bool $allowRelationshipWrites = false,
+        public array $clientIdAllowed = [],
+    ) {
+    }
+
+    public function allowClientId(string $type): bool
+    {
+        return $this->clientIdAllowed[$type] ?? false;
+    }
+}

--- a/src/Resource/Metadata/AttributeMetadata.php
+++ b/src/Resource/Metadata/AttributeMetadata.php
@@ -10,6 +10,7 @@ final class AttributeMetadata
         public string $name,
         public ?string $propertyPath = null,
         public bool $readable = true,
+        public bool $writable = true,
     ) {
     }
 }

--- a/src/Resource/Registry/ResourceRegistry.php
+++ b/src/Resource/Registry/ResourceRegistry.php
@@ -145,7 +145,7 @@ final class ResourceRegistry implements ResourceRegistryInterface
                 throw new LogicException(sprintf('Duplicate attribute "%s" detected on %s::%s.', $name, $member->getDeclaringClass()->getName(), $member->getName()));
             }
 
-            $attributes[$name] = new AttributeMetadata($name, $propertyPath, $instance->readable);
+            $attributes[$name] = new AttributeMetadata($name, $propertyPath, $instance->readable, $instance->writable);
         }
 
         return $attributes;

--- a/tests/Fixtures/InMemory/InMemoryPersister.php
+++ b/tests/Fixtures/InMemory/InMemoryPersister.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Fixtures\InMemory;
+
+use JsonApi\Symfony\Contract\Data\ChangeSet;
+use JsonApi\Symfony\Contract\Data\ResourcePersister;
+use JsonApi\Symfony\Http\Exception\ConflictException;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class InMemoryPersister implements ResourcePersister
+{
+    private PropertyAccessorInterface $accessor;
+
+    public function __construct(
+        private readonly InMemoryRepository $repository,
+        private readonly ResourceRegistryInterface $registry,
+        ?PropertyAccessorInterface $accessor = null,
+    ) {
+        $this->accessor = $accessor ?? PropertyAccess::createPropertyAccessor();
+    }
+
+    public function create(string $type, ChangeSet $changes, ?string $clientId = null): object
+    {
+        $metadata = $this->metadata($type);
+        $id = $clientId ?? Uuid::v4()->toRfc4122();
+
+        if ($this->repository->has($type, $id)) {
+            throw new ConflictException(sprintf('Resource "%s" with id "%s" already exists.', $type, $id));
+        }
+
+        $model = $this->repository->createPrototype($type);
+        $this->assignId($metadata, $model, $id);
+        $this->applyAttributes($model, $changes);
+
+        $this->repository->save($type, $model);
+
+        return $model;
+    }
+
+    public function update(string $type, string $id, ChangeSet $changes): object
+    {
+        $model = $this->repository->get($type, $id);
+        if ($model === null) {
+            throw new NotFoundException(sprintf('Resource "%s" with id "%s" was not found.', $type, $id));
+        }
+
+        $this->applyAttributes($model, $changes);
+        $this->repository->save($type, $model);
+
+        return $model;
+    }
+
+    public function delete(string $type, string $id): void
+    {
+        if (!$this->repository->has($type, $id)) {
+            throw new NotFoundException(sprintf('Resource "%s" with id "%s" was not found.', $type, $id));
+        }
+
+        $this->repository->remove($type, $id);
+    }
+
+    private function applyAttributes(object $model, ChangeSet $changes): void
+    {
+        foreach ($changes->attributes as $path => $value) {
+            $this->accessor->setValue($model, $path, $value);
+        }
+    }
+
+    private function assignId(ResourceMetadata $metadata, object $model, string $id): void
+    {
+        $path = $metadata->idPropertyPath ?? 'id';
+        $this->accessor->setValue($model, $path, $id);
+    }
+
+    private function metadata(string $type): ResourceMetadata
+    {
+        return $this->registry->getByType($type);
+    }
+}

--- a/tests/Fixtures/InMemory/InMemoryTransactionManager.php
+++ b/tests/Fixtures/InMemory/InMemoryTransactionManager.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Fixtures\InMemory;
+
+use JsonApi\Symfony\Contract\Tx\TransactionManager;
+
+final class InMemoryTransactionManager implements TransactionManager
+{
+    public function transactional(callable $callback)
+    {
+        return $callback();
+    }
+}

--- a/tests/Fixtures/Model/Article.php
+++ b/tests/Fixtures/Model/Article.php
@@ -29,7 +29,7 @@ final class Article
         $this->tags = $tags === [] ? [] : array_values($tags);
     }
 
-    #[Attribute(name: 'createdAt')]
+    #[Attribute(name: 'createdAt', writable: false)]
     public function getCreatedAt(): DateTimeImmutable
     {
         return $this->createdAt;

--- a/tests/Functional/ResourceWriteTest.php
+++ b/tests/Functional/ResourceWriteTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional;
+
+use JsonApi\Symfony\Http\Negotiation\MediaType;
+use JsonApi\Symfony\Http\Exception\BadRequestException;
+use JsonApi\Symfony\Http\Exception\ConflictException;
+use JsonApi\Symfony\Http\Exception\ForbiddenException;
+use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Query\Criteria;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ResourceWriteTest extends JsonApiTestCase
+{
+    public function testCreateArticleGeneratesIdAndReturnsDocument(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'articles',
+                'attributes' => [
+                    'title' => 'New post',
+                ],
+            ],
+        ];
+
+        $request = $this->jsonRequest('POST', '/api/articles', $payload);
+
+        $response = ($this->createController())($request, 'articles');
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame(MediaType::JSON_API, $response->headers->get('Content-Type'));
+
+        $document = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+        $id = $document['data']['id'];
+
+        self::assertNotEmpty($id);
+        self::assertSame('articles', $document['data']['type']);
+        self::assertSame('New post', $document['data']['attributes']['title']);
+        self::assertSame($document['data']['links']['self'], $response->headers->get('Location'));
+
+        $stored = $this->repository()->findOne('articles', $id, new Criteria());
+        self::assertNotNull($stored);
+    }
+
+    public function testCreateAuthorWithClientGeneratedId(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'authors',
+                'id' => 'author-123',
+                'attributes' => [
+                    'name' => 'Client Author',
+                ],
+            ],
+        ];
+
+        $response = ($this->createController())($this->jsonRequest('POST', '/api/authors', $payload), 'authors');
+
+        self::assertSame(201, $response->getStatusCode());
+
+        $document = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame('author-123', $document['data']['id']);
+        self::assertSame('Client Author', $document['data']['attributes']['name']);
+
+        $stored = $this->repository()->findOne('authors', 'author-123', new Criteria());
+        self::assertNotNull($stored);
+    }
+
+    public function testUpdateArticleReturnsUpdatedDocument(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'articles',
+                'id' => '1',
+                'attributes' => [
+                    'title' => 'Updated title',
+                ],
+            ],
+        ];
+
+        $response = ($this->updateController())($this->jsonRequest('PATCH', '/api/articles/1', $payload), 'articles', '1');
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $document = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame('Updated title', $document['data']['attributes']['title']);
+    }
+
+    public function testDeleteArticleRemovesResource(): void
+    {
+        $response = ($this->deleteController())('articles', '1');
+
+        self::assertSame(204, $response->getStatusCode());
+
+        self::assertNull($this->repository()->findOne('articles', '1', new Criteria()));
+    }
+
+    public function testPostTypeMismatchRaisesConflict(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'authors',
+                'attributes' => ['name' => 'Mismatch'],
+            ],
+        ];
+
+        $this->expectException(ConflictException::class);
+        ($this->createController())($this->jsonRequest('POST', '/api/articles', $payload), 'articles');
+    }
+
+    public function testPatchWithoutIdRaisesConflict(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'articles',
+                'attributes' => ['title' => 'Invalid'],
+            ],
+        ];
+
+        $this->expectException(ConflictException::class);
+        ($this->updateController())($this->jsonRequest('PATCH', '/api/articles/1', $payload), 'articles', '1');
+    }
+
+    public function testPatchMismatchedIdRaisesConflict(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'articles',
+                'id' => '2',
+                'attributes' => ['title' => 'Invalid'],
+            ],
+        ];
+
+        $this->expectException(ConflictException::class);
+        ($this->updateController())($this->jsonRequest('PATCH', '/api/articles/1', $payload), 'articles', '1');
+    }
+
+    public function testPostClientIdWhenNotAllowedRaisesForbidden(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'articles',
+                'id' => 'custom',
+                'attributes' => ['title' => 'Invalid'],
+            ],
+        ];
+
+        $this->expectException(ForbiddenException::class);
+        ($this->createController())($this->jsonRequest('POST', '/api/articles', $payload), 'articles');
+    }
+
+    public function testWritingUnknownAttributeRaisesBadRequest(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'articles',
+                'attributes' => ['unknown' => 'value'],
+            ],
+        ];
+
+        $this->expectException(BadRequestException::class);
+        ($this->createController())($this->jsonRequest('POST', '/api/articles', $payload), 'articles');
+    }
+
+    public function testWritingReadOnlyAttributeRaisesBadRequest(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'articles',
+                'attributes' => ['createdAt' => '2024-01-01T00:00:00Z'],
+            ],
+        ];
+
+        $this->expectException(BadRequestException::class);
+        ($this->createController())($this->jsonRequest('POST', '/api/articles', $payload), 'articles');
+    }
+
+    public function testRelationshipsInPayloadAreRejected(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'articles',
+                'attributes' => ['title' => 'With relationship'],
+                'relationships' => ['author' => []],
+            ],
+        ];
+
+        $this->expectException(BadRequestException::class);
+        ($this->createController())($this->jsonRequest('POST', '/api/articles', $payload), 'articles');
+    }
+
+    public function testClientIdConflictProduces409(): void
+    {
+        $payload = [
+            'data' => [
+                'type' => 'authors',
+                'id' => '1',
+                'attributes' => ['name' => 'Duplicate'],
+            ],
+        ];
+
+        $this->expectException(ConflictException::class);
+        ($this->createController())($this->jsonRequest('POST', '/api/authors', $payload), 'authors');
+    }
+
+    public function testDeleteUnknownResourceRaises404(): void
+    {
+        $this->expectException(NotFoundException::class);
+        ($this->deleteController())('articles', '999');
+    }
+
+    public function testUnsupportedMediaTypeResultsIn415(): void
+    {
+        $payload = json_encode(['data' => ['type' => 'articles', 'attributes' => ['title' => 'Invalid']]], JSON_THROW_ON_ERROR);
+        $request = Request::create('/api/articles', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $payload);
+
+        $this->expectException(JsonApiHttpException::class);
+        ($this->createController())($request, 'articles');
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function jsonRequest(string $method, string $uri, array $payload): Request
+    {
+        $json = json_encode($payload, JSON_THROW_ON_ERROR);
+
+        return Request::create(
+            $uri,
+            $method,
+            server: [
+                'CONTENT_TYPE' => MediaType::JSON_API,
+                'HTTP_ACCEPT' => MediaType::JSON_API,
+            ],
+            content: $json,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add write-layer contracts plus ChangeSet denormalisation and validation utilities for JSON:API documents
- implement POST/PATCH/DELETE resource controllers and service wiring with configurable client-generated IDs
- introduce in-memory persister/transaction manager and functional coverage for write success and failure paths

## Testing
- make test
- vendor/bin/phpstan analyse --memory-limit=512M *(fails: existing type analysis errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ce6a8384832fb9d07f09208c41df