### PR TITLE
Add JSON:API relationship endpoints and metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Stage 2 ships fully functional read endpoints and foundational writes:
 
 * Attribute-driven metadata registry with automatic discovery of attributes and relationships.
 * `GET /api/{type}` and `GET /api/{type}/{id}` controllers with JSON:API 1.1 compliant documents.
+* Relationship endpoints for `GET /api/{type}/{id}/relationships/{relationship}` and
+  `GET /api/{type}/{id}/{relationship}` with linkage validation, configurable responses, and
+  metadata support.
 * Query parsing for `include`, `fields[TYPE]`, `sort`, `page[number]`, and `page[size]` with robust validation.
 * Pagination helpers generating `self`, `first`, `prev`, `next`, and `last` links that retain other query parameters.
 * Document builder producing `data`, `included`, `links`, `meta`, and `jsonapi.version` for any combination of sparse fieldsets and includes.

--- a/src/Bridge/Symfony/DependencyInjection/JsonApiExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/JsonApiExtension.php
@@ -26,6 +26,8 @@ final class JsonApiExtension extends Extension
         $container->setParameter('jsonapi.sorting.whitelist', $config['sorting']['whitelist']);
         $container->setParameter('jsonapi.write.allow_relationship_writes', $config['write']['allow_relationship_writes']);
         $container->setParameter('jsonapi.write.client_generated_ids', $config['write']['client_generated_ids']);
+        $container->setParameter('jsonapi.relationships.write_response', $config['relationships']['write_response']);
+        $container->setParameter('jsonapi.relationships.linkage_in_resource', $config['relationships']['linkage_in_resource']);
 
         $this->registerAutoconfiguration($container);
 

--- a/src/Contract/Data/ExistenceChecker.php
+++ b/src/Contract/Data/ExistenceChecker.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Data;
+
+interface ExistenceChecker
+{
+    public function exists(string $type, string $id): bool;
+}

--- a/src/Contract/Data/RelationshipReader.php
+++ b/src/Contract/Data/RelationshipReader.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Data;
+
+use JsonApi\Symfony\Query\Criteria;
+use JsonApi\Symfony\Query\Pagination;
+
+interface RelationshipReader
+{
+    public function getToOneId(string $type, string $id, string $rel): ?string;
+
+    public function getToManyIds(string $type, string $id, string $rel, Pagination $pagination): SliceIds;
+
+    public function getRelatedResource(string $type, string $id, string $rel): ?object;
+
+    public function getRelatedCollection(string $type, string $id, string $rel, Criteria $criteria): Slice;
+}

--- a/src/Contract/Data/RelationshipUpdater.php
+++ b/src/Contract/Data/RelationshipUpdater.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Data;
+
+interface RelationshipUpdater
+{
+    public function replaceToOne(string $type, string $id, string $rel, ?ResourceIdentifier $target): void;
+
+    /**
+     * @param list<ResourceIdentifier> $targets
+     */
+    public function replaceToMany(string $type, string $id, string $rel, array $targets): void;
+
+    /**
+     * @param list<ResourceIdentifier> $targets
+     */
+    public function addToMany(string $type, string $id, string $rel, array $targets): void;
+
+    /**
+     * @param list<ResourceIdentifier> $targets
+     */
+    public function removeFromToMany(string $type, string $id, string $rel, array $targets): void;
+}

--- a/src/Contract/Data/SliceIds.php
+++ b/src/Contract/Data/SliceIds.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Contract\Data;
+
+final class SliceIds
+{
+    /**
+     * @param list<string> $ids
+     */
+    public function __construct(
+        public array $ids,
+        public int $pageNumber,
+        public int $pageSize,
+        public int $totalItems,
+    ) {
+    }
+}

--- a/src/Http/Controller/CollectionController.php
+++ b/src/Http/Controller/CollectionController.php
@@ -11,8 +11,8 @@ use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
 
 #[Route(path: '/api/{type}', name: 'jsonapi.collection', methods: ['GET'])]
 final class CollectionController

--- a/src/Http/Controller/RelatedController.php
+++ b/src/Http/Controller/RelatedController.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Controller;
+
+use JsonApi\Symfony\Contract\Data\RelationshipReader;
+use JsonApi\Symfony\Http\Document\DocumentBuilder;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Http\Negotiation\MediaType;
+use JsonApi\Symfony\Http\Request\QueryParser;
+use JsonApi\Symfony\Resource\Metadata\RelationshipMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/api/{type}/{id}/{rel}', methods: ['GET'], name: 'jsonapi.related')]
+final class RelatedController
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly RelationshipReader $reader,
+        private readonly QueryParser $parser,
+        private readonly DocumentBuilder $document,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $type, string $id, string $rel): JsonResponse
+    {
+        if (!$this->registry->hasType($type)) {
+            throw new NotFoundException(sprintf('Resource type "%s" not found.', $type));
+        }
+
+        $metadata = $this->registry->getByType($type);
+        $relationship = $metadata->relationships[$rel] ?? null;
+
+        if (!$relationship instanceof RelationshipMetadata) {
+            throw new NotFoundException(sprintf('Relationship "%s" not found on resource "%s".', $rel, $type));
+        }
+
+        if ($relationship->toMany) {
+            $targetType = $relationship->targetType ?? $rel;
+            $criteria = $this->parser->parse($targetType, $request);
+            $slice = $this->reader->getRelatedCollection($type, $id, $rel, $criteria);
+            $document = $this->document->buildCollection($targetType, $slice->items, $criteria, $slice, $request);
+        } else {
+            $model = $this->reader->getRelatedResource($type, $id, $rel);
+
+            if ($model === null) {
+                $document = [
+                    'jsonapi' => ['version' => '1.1'],
+                    'links' => ['self' => $request->getUri()],
+                    'data' => null,
+                ];
+            } else {
+                $targetType = $relationship->targetType;
+                if ($targetType === null) {
+                    $targetMetadata = $this->registry->getByClass($model::class);
+                    if ($targetMetadata === null) {
+                        throw new NotFoundException(sprintf('Unable to resolve target type for relationship "%s".', $rel));
+                    }
+
+                    $targetType = $targetMetadata->type;
+                }
+
+                $criteria = $this->parser->parse($targetType, $request);
+                $document = $this->document->buildResource($targetType, $model, $criteria, $request);
+            }
+        }
+
+        return new JsonResponse(
+            $document,
+            JsonResponse::HTTP_OK,
+            ['Content-Type' => MediaType::JSON_API],
+        );
+    }
+}

--- a/src/Http/Controller/RelationshipGetController.php
+++ b/src/Http/Controller/RelationshipGetController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Controller;
+
+use JsonApi\Symfony\Http\Negotiation\MediaType;
+use JsonApi\Symfony\Http\Relationship\LinkageBuilder;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/api/{type}/{id}/relationships/{rel}', methods: ['GET'], name: 'jsonapi.relationship.get')]
+final class RelationshipGetController
+{
+    public function __construct(private readonly LinkageBuilder $linkage)
+    {
+    }
+
+    public function __invoke(Request $request, string $type, string $id, string $rel): JsonResponse
+    {
+        [, $data] = $this->linkage->read($type, $id, $rel, $request);
+
+        return new JsonResponse(
+            [
+                'jsonapi' => ['version' => '1.1'],
+                'links' => ['self' => $request->getUri()],
+                'data' => $data,
+            ],
+            JsonResponse::HTTP_OK,
+            ['Content-Type' => MediaType::JSON_API],
+        );
+    }
+}

--- a/src/Http/Controller/RelationshipWriteController.php
+++ b/src/Http/Controller/RelationshipWriteController.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Controller;
+
+use JsonApi\Symfony\Contract\Data\RelationshipUpdater;
+use JsonApi\Symfony\Http\Exception\BadRequestException;
+use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
+use JsonApi\Symfony\Http\Negotiation\MediaType;
+use JsonApi\Symfony\Http\Relationship\LinkageBuilder;
+use JsonApi\Symfony\Http\Relationship\WriteRelationshipsResponseConfig;
+use JsonApi\Symfony\Http\Write\RelationshipDocumentValidator;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/api/{type}/{id}/relationships/{rel}', methods: ['PATCH', 'POST', 'DELETE'], name: 'jsonapi.relationship.write')]
+final class RelationshipWriteController
+{
+    public function __construct(
+        private readonly RelationshipDocumentValidator $validator,
+        private readonly RelationshipUpdater $updater,
+        private readonly LinkageBuilder $linkage,
+        private readonly WriteRelationshipsResponseConfig $responseConfig,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $type, string $id, string $rel): Response
+    {
+        $payload = $this->decode($request);
+        /** @var array{kind: 'to-one'|'to-many', data: null|array{type: string, id: string}|list<array{type: string, id: string}>} $validated */
+        $validated = $this->validator->validate($type, $id, $rel, $payload, $request->getMethod());
+        $kind = $validated['kind'];
+        $data = $validated['data'];
+
+        if ($request->isMethod('PATCH')) {
+            if ($kind === 'to-one') {
+                /** @var array{type: string, id: string}|null $data */
+                $this->updater->replaceToOne($type, $id, $rel, $this->linkage->toIdentifierOrNull($data));
+            } else {
+                /** @var list<array{type: string, id: string}> $data */
+                $this->updater->replaceToMany($type, $id, $rel, $this->linkage->toIdentifiers($data));
+            }
+        } elseif ($request->isMethod('POST')) {
+            /** @var list<array{type: string, id: string}> $data */
+            $this->updater->addToMany($type, $id, $rel, $this->linkage->toIdentifiers($data));
+        } else {
+            /** @var list<array{type: string, id: string}> $data */
+            $this->updater->removeFromToMany($type, $id, $rel, $this->linkage->toIdentifiers($data));
+        }
+
+        if ($this->responseConfig->mode === '204') {
+            return new Response(null, Response::HTTP_NO_CONTENT, ['Content-Type' => MediaType::JSON_API]);
+        }
+
+        [, $data] = $this->linkage->read($type, $id, $rel, $request);
+
+        return new JsonResponse(
+            [
+                'jsonapi' => ['version' => '1.1'],
+                'links' => ['self' => $request->getUri()],
+                'data' => $data,
+            ],
+            JsonResponse::HTTP_OK,
+            ['Content-Type' => MediaType::JSON_API],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decode(Request $request): ?array
+    {
+        $contentType = $request->headers->get('Content-Type');
+        if ($contentType !== null && $this->normalizeMediaType($contentType) !== MediaType::JSON_API) {
+            throw JsonApiHttpException::unsupportedMediaType('JSON:API requires the "application/vnd.api+json" media type.');
+        }
+
+        $content = (string) $request->getContent();
+
+        if ($content === '') {
+            return null;
+        }
+
+        $decoded = json_decode($content, true);
+        if ($decoded === null && json_last_error() !== \JSON_ERROR_NONE) {
+            throw new BadRequestException(sprintf('Malformed JSON: %s.', json_last_error_msg()));
+        }
+
+        if ($decoded === null) {
+            return null;
+        }
+
+        if (!is_array($decoded) || array_is_list($decoded)) {
+            throw new BadRequestException('Request body must be a valid JSON object.');
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    private function normalizeMediaType(string $value): string
+    {
+        $normalized = trim(strtolower($value));
+        $semicolonPosition = strpos($normalized, ';');
+
+        if ($semicolonPosition === false) {
+            return $normalized;
+        }
+
+        return substr($normalized, 0, $semicolonPosition);
+    }
+}

--- a/src/Http/Controller/UpdateResourceController.php
+++ b/src/Http/Controller/UpdateResourceController.php
@@ -8,8 +8,8 @@ use JsonApi\Symfony\Contract\Data\ResourcePersister;
 use JsonApi\Symfony\Contract\Tx\TransactionManager;
 use JsonApi\Symfony\Http\Document\DocumentBuilder;
 use JsonApi\Symfony\Http\Exception\BadRequestException;
-use JsonApi\Symfony\Http\Exception\NotFoundException;
 use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
 use JsonApi\Symfony\Http\Negotiation\MediaType;
 use JsonApi\Symfony\Http\Write\ChangeSetFactory;
 use JsonApi\Symfony\Http\Write\InputDocumentValidator;
@@ -63,14 +63,14 @@ final class UpdateResourceController
             throw JsonApiHttpException::unsupportedMediaType('JSON:API requires the "application/vnd.api+json" media type.');
         }
 
-        $content = $request->getContent();
+        $content = (string) $request->getContent();
 
-        if ($content === false || $content === '') {
+        if ($content === '') {
             throw new BadRequestException('Request body must not be empty.');
         }
 
         $decoded = json_decode($content, true);
-        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+        if ($decoded === null && json_last_error() !== \JSON_ERROR_NONE) {
             throw new BadRequestException(sprintf('Malformed JSON: %s.', json_last_error_msg()));
         }
 

--- a/src/Http/Link/LinkGenerator.php
+++ b/src/Http/Link/LinkGenerator.php
@@ -28,11 +28,30 @@ final class LinkGenerator
         );
     }
 
+    public function relationshipSelf(string $type, string $id, string $relationship): string
+    {
+        return $this->urls->generate(
+            'jsonapi.relationship.get',
+            ['type' => $type, 'id' => $id, 'rel' => $relationship],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+    }
+
+    public function relationshipRelated(string $type, string $id, string $relationship): string
+    {
+        return $this->urls->generate(
+            'jsonapi.related',
+            ['type' => $type, 'id' => $id, 'rel' => $relationship],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+    }
+
     /**
      * @return array<string, string>
      */
     public function collectionPagination(string $type, Pagination $pagination, int $total, Request $request): array
     {
+        /** @var array<string, mixed> $query */
         $query = $request->query->all();
         $links = [];
         $size = $pagination->size;
@@ -58,6 +77,10 @@ final class LinkGenerator
      */
     private function generateCollectionUrl(string $type, int $number, int $size, array $query): string
     {
+        if (!isset($query['page']) || !is_array($query['page'])) {
+            $query['page'] = [];
+        }
+
         $query['page']['number'] = $number;
         $query['page']['size'] = $size;
         $query['type'] = $type;

--- a/src/Http/Relationship/LinkageBuilder.php
+++ b/src/Http/Relationship/LinkageBuilder.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Relationship;
+
+use JsonApi\Symfony\Contract\Data\RelationshipReader;
+use JsonApi\Symfony\Contract\Data\ResourceIdentifier;
+use JsonApi\Symfony\Http\Exception\BadRequestException;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Http\Request\PaginationConfig;
+use JsonApi\Symfony\Query\Pagination;
+use JsonApi\Symfony\Resource\Metadata\RelationshipMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class LinkageBuilder
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly RelationshipReader $reader,
+        private readonly PaginationConfig $paginationConfig,
+    ) {
+    }
+
+    /**
+     * @return array{0: 'to-one'|'to-many', 1: null|array<string, string>|list<array<string, string>>}
+     */
+    public function read(string $type, string $id, string $rel, Request $request): array
+    {
+        if (!$this->registry->hasType($type)) {
+            throw new NotFoundException(sprintf('Resource type "%s" not found.', $type));
+        }
+
+        $metadata = $this->registry->getByType($type);
+        $relationship = $metadata->relationships[$rel] ?? null;
+
+        if (!$relationship instanceof RelationshipMetadata) {
+            throw new NotFoundException(sprintf('Relationship "%s" not found on resource "%s".', $rel, $type));
+        }
+
+        if ($relationship->toMany) {
+            $pagination = $this->parsePagination($request);
+            $slice = $this->reader->getToManyIds($type, $id, $rel, $pagination);
+            $targetType = $this->determineTargetType($relationship, $rel);
+
+            $data = array_map(
+                static fn (string $targetId): array => ['type' => $targetType, 'id' => $targetId],
+                $slice->ids,
+            );
+
+            return ['to-many', $data];
+        }
+
+        $targetId = $this->reader->getToOneId($type, $id, $rel);
+
+        if ($targetId === null) {
+            return ['to-one', null];
+        }
+
+        return ['to-one', ['type' => $this->determineTargetType($relationship, $rel), 'id' => $targetId]];
+    }
+
+    /**
+     * @param array{type: string, id: string}|null $data
+     */
+    public function toIdentifierOrNull(?array $data): ?ResourceIdentifier
+    {
+        if ($data === null) {
+            return null;
+        }
+
+        return new ResourceIdentifier($data['type'], $data['id']);
+    }
+
+    /**
+     * @param list<array{type: string, id: string}> $data
+     *
+     * @return list<ResourceIdentifier>
+     */
+    public function toIdentifiers(array $data): array
+    {
+        return array_map(
+            static fn (array $identifier): ResourceIdentifier => new ResourceIdentifier($identifier['type'], $identifier['id']),
+            $data,
+        );
+    }
+
+    private function determineTargetType(RelationshipMetadata $relationship, string $default): string
+    {
+        if ($relationship->targetType !== null) {
+            return $relationship->targetType;
+        }
+
+        return $default;
+    }
+
+    private function parsePagination(Request $request): Pagination
+    {
+        /** @var array<string, mixed> $page */
+        $page = (array) $request->query->all('page');
+
+        $number = $page['number'] ?? 1;
+        $size = $page['size'] ?? $this->paginationConfig->defaultSize;
+
+        $number = $this->toInt($number, 'page[number]');
+        $size = $this->toInt($size, 'page[size]');
+
+        if ($number < 1) {
+            throw new BadRequestException('page[number] must be greater than or equal to 1.');
+        }
+
+        if ($size < 1 || $size > $this->paginationConfig->maxSize) {
+            throw new BadRequestException(sprintf(
+                'page[size] must be between 1 and %d.',
+                $this->paginationConfig->maxSize,
+            ));
+        }
+
+        return new Pagination($number, $size);
+    }
+
+    private function toInt(mixed $value, string $name): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (!is_string($value) || !preg_match('/^-?\d+$/', $value)) {
+            throw new BadRequestException(sprintf('%s must be an integer.', $name));
+        }
+
+        return (int) $value;
+    }
+}

--- a/src/Http/Relationship/LinkageBuilder.php
+++ b/src/Http/Relationship/LinkageBuilder.php
@@ -12,6 +12,7 @@ use JsonApi\Symfony\Http\Request\PaginationConfig;
 use JsonApi\Symfony\Query\Pagination;
 use JsonApi\Symfony\Resource\Metadata\RelationshipMetadata;
 use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use LogicException;
 use Symfony\Component\HttpFoundation\Request;
 
 final class LinkageBuilder
@@ -92,7 +93,19 @@ final class LinkageBuilder
             return $relationship->targetType;
         }
 
-        return $default;
+        if ($relationship->targetClass !== null) {
+            $metadata = $this->registry->getByClass($relationship->targetClass);
+
+            if ($metadata !== null) {
+                return $metadata->type;
+            }
+        }
+
+        if ($this->registry->hasType($default)) {
+            return $default;
+        }
+
+        throw new LogicException(sprintf('Unable to determine target type for relationship "%s".', $relationship->name));
     }
 
     private function parsePagination(Request $request): Pagination

--- a/src/Http/Relationship/WriteRelationshipsResponseConfig.php
+++ b/src/Http/Relationship/WriteRelationshipsResponseConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Relationship;
+
+use InvalidArgumentException;
+
+final class WriteRelationshipsResponseConfig
+{
+    /**
+     * @param 'linkage'|'204' $mode
+     */
+    public function __construct(public string $mode = 'linkage')
+    {
+        if (!in_array($this->mode, ['linkage', '204'], true)) {
+            throw new InvalidArgumentException(sprintf('Unsupported relationship write response mode "%s".', $this->mode));
+        }
+    }
+}

--- a/src/Http/Request/QueryParser.php
+++ b/src/Http/Request/QueryParser.php
@@ -35,13 +35,8 @@ final class QueryParser
 
     private function parsePagination(Request $request): Pagination
     {
-        $page = $request->query->all('page');
-        if (!is_array($page)) {
-            $page = $request->query->all()['page'] ?? [];
-            if (!is_array($page)) {
-                $page = [];
-            }
-        }
+        /** @var array<string, mixed> $page */
+        $page = (array) $request->query->all('page');
 
         $number = $page['number'] ?? 1;
         $size = $page['size'] ?? $this->paginationConfig->defaultSize;
@@ -68,6 +63,7 @@ final class QueryParser
      */
     private function parseFields(Request $request): array
     {
+        /** @var array<string, mixed> $query */
         $query = $request->query->all();
         $fields = [];
 
@@ -79,7 +75,7 @@ final class QueryParser
             throw new BadRequestHttpException('fields parameter must be an array keyed by resource type.');
         }
 
-        /** @var array<string, mixed> $rawFields */
+        /** @var array<int|string, mixed> $rawFields */
         $rawFields = $query['fields'];
 
         foreach ($rawFields as $resourceType => $list) {

--- a/src/Http/Request/SortingWhitelist.php
+++ b/src/Http/Request/SortingWhitelist.php
@@ -18,8 +18,6 @@ final class SortingWhitelist
      */
     public function allowedFor(string $type): array
     {
-        $fields = $this->map[$type] ?? [];
-
-        return array_values($fields);
+        return $this->map[$type] ?? [];
     }
 }

--- a/src/Http/Write/InputDocumentValidator.php
+++ b/src/Http/Write/InputDocumentValidator.php
@@ -19,6 +19,8 @@ final class InputDocumentValidator
     }
 
     /**
+     * @param array<int|string, mixed> $payload
+     *
      * @return array{type: string, id: ?string, attributes: array<string, mixed>, relationships: array<string, mixed>}
      */
     public function validateAndExtract(string $routeType, ?string $routeId, array $payload, string $method): array
@@ -72,7 +74,7 @@ final class InputDocumentValidator
                 throw new BadRequestException('The "relationships" member must be an object.');
             }
 
-            /** @var array<string, mixed> $relationships */
+            /** @var array<int|string, mixed> $relationships */
             $relationships = $data['relationships'];
 
             if ($relationships !== [] && !$this->config->allowRelationshipWrites) {
@@ -82,6 +84,9 @@ final class InputDocumentValidator
             if ($relationships !== [] && array_is_list($relationships)) {
                 throw new BadRequestException('The "relationships" member must be an object.');
             }
+
+            /** @var array<string, mixed> $relationships */
+            $relationships = $relationships;
         }
 
         $attributes = [];
@@ -90,13 +95,16 @@ final class InputDocumentValidator
                 throw new BadRequestException('The "attributes" member must be an object.');
             }
 
-            /** @var array<string, mixed> $attributes */
+            /** @var array<int|string, mixed> $attributes */
             $attributes = $data['attributes'];
         }
 
         if ($attributes !== [] && array_is_list($attributes)) {
             throw new BadRequestException('The "attributes" member must be an object.');
         }
+
+        /** @var array<string, mixed> $attributes */
+        $attributes = $attributes;
 
         $metadata = $this->registry->getByType($routeType);
 

--- a/src/Http/Write/RelationshipDocumentValidator.php
+++ b/src/Http/Write/RelationshipDocumentValidator.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Write;
+
+use JsonApi\Symfony\Contract\Data\ExistenceChecker;
+use JsonApi\Symfony\Http\Exception\BadRequestException;
+use JsonApi\Symfony\Http\Exception\ConflictException;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Resource\Metadata\RelationshipMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+
+final class RelationshipDocumentValidator
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly ExistenceChecker $exists,
+    ) {
+    }
+
+    /**
+     * @param array<int|string, mixed>|null $payload
+     *
+     * @return array{kind: 'to-one'|'to-many', data: null|array{type: string, id: string}|list<array{type: string, id: string}>}
+     */
+    public function validate(string $routeType, string $routeId, string $relationship, ?array $payload, string $method): array
+    {
+        if (!$this->registry->hasType($routeType)) {
+            throw new NotFoundException(sprintf('Resource type "%s" not found.', $routeType));
+        }
+
+        if (!$this->exists->exists($routeType, $routeId)) {
+            throw new NotFoundException(sprintf('Resource "%s" with id "%s" was not found.', $routeType, $routeId));
+        }
+
+        $metadata = $this->registry->getByType($routeType);
+        $relationshipMetadata = $metadata->relationships[$relationship] ?? null;
+
+        if (!$relationshipMetadata instanceof RelationshipMetadata) {
+            throw new NotFoundException(sprintf('Relationship "%s" not found on resource "%s".', $relationship, $routeType));
+        }
+
+        $kind = $relationshipMetadata->toMany ? 'to-many' : 'to-one';
+
+        if ($payload === null) {
+            throw new BadRequestException('Request body must not be empty.');
+        }
+
+        if (!array_key_exists('data', $payload)) {
+            throw new BadRequestException('Document must contain a "data" member.');
+        }
+
+        if ($kind === 'to-one') {
+            if ($method === 'POST' || $method === 'DELETE') {
+                throw new MethodNotAllowedHttpException(['PATCH'], 'Only PATCH is allowed for to-one relationship updates.');
+            }
+
+            return [
+                'kind' => $kind,
+                'data' => $this->validateToOneData($relationshipMetadata, $payload['data']),
+            ];
+        }
+
+        return [
+            'kind' => $kind,
+            'data' => $this->validateToManyData($relationshipMetadata, $payload['data'], $method),
+        ];
+    }
+
+    /**
+     * @param mixed $data
+     *
+     * @return array{type: string, id: string}|null
+     */
+    private function validateToOneData(RelationshipMetadata $metadata, mixed $data): ?array
+    {
+        if ($data === null) {
+            if (!$metadata->nullable) {
+                throw new ConflictException(sprintf('Relationship "%s" cannot be set to null.', $metadata->name));
+            }
+
+            return null;
+        }
+
+        if (!is_array($data) || array_is_list($data)) {
+            throw new BadRequestException('Relationship data must be an object.');
+        }
+
+        $type = $data['type'] ?? null;
+        $id = $data['id'] ?? null;
+
+        if (!is_string($type) || $type === '') {
+            throw new BadRequestException('Relationship type must be a non-empty string.');
+        }
+
+        if (!is_string($id) || $id === '') {
+            throw new BadRequestException('Relationship id must be a non-empty string.');
+        }
+
+        if ($metadata->targetType !== null && $metadata->targetType !== $type) {
+            throw new ConflictException(sprintf('Relationship "%s" must reference resources of type "%s".', $metadata->name, $metadata->targetType));
+        }
+
+        if (!$this->exists->exists($type, $id)) {
+            throw new NotFoundException(sprintf('Related resource "%s" with id "%s" was not found.', $type, $id));
+        }
+
+        return ['type' => $type, 'id' => $id];
+    }
+
+    /**
+     * @param mixed $data
+     *
+     * @return list<array{type: string, id: string}>
+     */
+    private function validateToManyData(RelationshipMetadata $metadata, mixed $data, string $method): array
+    {
+        $allowed = ['PATCH', 'POST', 'DELETE'];
+
+        if (!in_array($method, $allowed, true)) {
+            throw new MethodNotAllowedHttpException($allowed, sprintf('Method %s is not allowed for relationship "%s".', $method, $metadata->name));
+        }
+
+        if (!is_array($data) || !array_is_list($data)) {
+            throw new BadRequestException('Relationship data must be an array of resource identifier objects.');
+        }
+
+        $unique = [];
+        $seen = [];
+
+        foreach ($data as $index => $item) {
+            if (!is_array($item) || array_is_list($item)) {
+                throw new BadRequestException(sprintf('Relationship data entry at index %d must be an object.', $index));
+            }
+
+            $type = $item['type'] ?? null;
+            $id = $item['id'] ?? null;
+
+            if (!is_string($type) || $type === '') {
+                throw new BadRequestException(sprintf('Relationship data entry at index %d must contain a non-empty "type".', $index));
+            }
+
+            if (!is_string($id) || $id === '') {
+                throw new BadRequestException(sprintf('Relationship data entry at index %d must contain a non-empty "id".', $index));
+            }
+
+            if ($metadata->targetType !== null && $metadata->targetType !== $type) {
+                throw new ConflictException(sprintf('Relationship "%s" must reference resources of type "%s".', $metadata->name, $metadata->targetType));
+            }
+
+            if (!$this->exists->exists($type, $id)) {
+                throw new NotFoundException(sprintf('Related resource "%s" with id "%s" was not found.', $type, $id));
+            }
+
+            $key = $type . ':' . $id;
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $unique[] = ['type' => $type, 'id' => $id];
+        }
+
+        return $unique;
+    }
+}

--- a/src/Resource/Attribute/Relationship.php
+++ b/src/Resource/Attribute/Relationship.php
@@ -12,6 +12,7 @@ final class Relationship
     public function __construct(
         public readonly bool $toMany = false,
         public readonly ?string $inverse = null,
+        public readonly ?string $targetType = null,
     ) {
     }
 }

--- a/src/Resource/Metadata/RelationshipMetadata.php
+++ b/src/Resource/Metadata/RelationshipMetadata.php
@@ -12,6 +12,7 @@ final class RelationshipMetadata
         public ?string $targetType = null,
         public ?string $propertyPath = null,
         public ?string $targetClass = null,
+        public bool $nullable = true,
     ) {
     }
 }

--- a/src/Resource/Metadata/ResourceMetadata.php
+++ b/src/Resource/Metadata/ResourceMetadata.php
@@ -11,8 +11,9 @@ namespace JsonApi\Symfony\Resource\Metadata;
 final class ResourceMetadata
 {
     /**
-     * @param AttributeMap        $attributes
-     * @param RelationshipMap     $relationships
+     * @param AttributeMap    $attributes
+     * @param RelationshipMap $relationships
+     * @param class-string    $class
      */
     public function __construct(
         public string $type,

--- a/tests/Fixtures/InMemory/InMemoryExistenceChecker.php
+++ b/tests/Fixtures/InMemory/InMemoryExistenceChecker.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Fixtures\InMemory;
+
+use JsonApi\Symfony\Contract\Data\ExistenceChecker;
+
+final class InMemoryExistenceChecker implements ExistenceChecker
+{
+    public function __construct(private readonly InMemoryRepository $repository)
+    {
+    }
+
+    public function exists(string $type, string $id): bool
+    {
+        return $this->repository->has($type, $id);
+    }
+}

--- a/tests/Fixtures/InMemory/InMemoryRelationshipReader.php
+++ b/tests/Fixtures/InMemory/InMemoryRelationshipReader.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Fixtures\InMemory;
+
+use JsonApi\Symfony\Contract\Data\RelationshipReader;
+use JsonApi\Symfony\Contract\Data\Slice;
+use JsonApi\Symfony\Contract\Data\SliceIds;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Query\Criteria;
+use JsonApi\Symfony\Query\Pagination;
+use JsonApi\Symfony\Query\Sorting;
+use JsonApi\Symfony\Resource\Metadata\RelationshipMetadata;
+use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use Stringable;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+final class InMemoryRelationshipReader implements RelationshipReader
+{
+    private PropertyAccessorInterface $accessor;
+
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly InMemoryRepository $repository,
+        ?PropertyAccessorInterface $accessor = null,
+    ) {
+        $this->accessor = $accessor ?? PropertyAccess::createPropertyAccessor();
+    }
+
+    public function getToOneId(string $type, string $id, string $rel): ?string
+    {
+        $model = $this->requireModel($type, $id);
+        $relationship = $this->requireRelationship($type, $rel);
+        $related = $this->accessor->getValue($model, $relationship->propertyPath ?? $rel);
+
+        if ($related === null || !is_object($related)) {
+            return null;
+        }
+
+        $targetMetadata = $this->resolveTargetMetadata($relationship, $related);
+        if ($targetMetadata === null) {
+            return null;
+        }
+
+        return $this->resolveId($targetMetadata, $related);
+    }
+
+    public function getToManyIds(string $type, string $id, string $rel, Pagination $pagination): SliceIds
+    {
+        $model = $this->requireModel($type, $id);
+        $relationship = $this->requireRelationship($type, $rel);
+        $items = $this->getRelatedItems($model, $relationship);
+        $total = count($items);
+        $offset = max(0, ($pagination->number - 1) * $pagination->size);
+        $chunk = array_slice($items, $offset, $pagination->size);
+
+        $ids = [];
+        foreach ($chunk as $item) {
+            $targetMetadata = $this->resolveTargetMetadata($relationship, $item);
+            if ($targetMetadata === null) {
+                continue;
+            }
+
+            $ids[] = $this->resolveId($targetMetadata, $item);
+        }
+
+        return new SliceIds($ids, $pagination->number, $pagination->size, $total);
+    }
+
+    public function getRelatedResource(string $type, string $id, string $rel): ?object
+    {
+        $model = $this->requireModel($type, $id);
+        $relationship = $this->requireRelationship($type, $rel);
+        $related = $this->accessor->getValue($model, $relationship->propertyPath ?? $rel);
+
+        return is_object($related) ? $related : null;
+    }
+
+    public function getRelatedCollection(string $type, string $id, string $rel, Criteria $criteria): Slice
+    {
+        $model = $this->requireModel($type, $id);
+        $relationship = $this->requireRelationship($type, $rel);
+        $items = $this->getRelatedItems($model, $relationship);
+        $items = $this->applySort($relationship, $items, $criteria->sort);
+
+        $total = count($items);
+        $size = $criteria->pagination->size;
+        $number = $criteria->pagination->number;
+        $offset = max(0, ($number - 1) * $size);
+        $items = array_slice($items, $offset, $size);
+
+        return new Slice($items, $number, $size, $total);
+    }
+
+    private function requireModel(string $type, string $id): object
+    {
+        $model = $this->repository->get($type, $id);
+        if ($model === null) {
+            throw new NotFoundException(sprintf('Resource "%s" with id "%s" was not found.', $type, $id));
+        }
+
+        return $model;
+    }
+
+    private function requireRelationship(string $type, string $name): RelationshipMetadata
+    {
+        $metadata = $this->registry->getByType($type);
+        if (!isset($metadata->relationships[$name])) {
+            throw new NotFoundException(sprintf('Relationship "%s" not found on resource "%s".', $name, $type));
+        }
+
+        /** @var RelationshipMetadata $relationship */
+        $relationship = $metadata->relationships[$name];
+
+        return $relationship;
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function getRelatedItems(object $model, RelationshipMetadata $relationship): array
+    {
+        $value = $this->accessor->getValue($model, $relationship->propertyPath ?? $relationship->name);
+
+        if ($value === null) {
+            return [];
+        }
+
+        if (!$relationship->toMany) {
+            return is_object($value) ? [$value] : [];
+        }
+
+        if (is_array($value)) {
+            $items = [];
+            foreach ($value as $item) {
+                if ($item !== null && is_object($item)) {
+                    $items[] = $item;
+                }
+            }
+
+            return $items;
+        }
+
+        if ($value instanceof \Traversable) {
+            $items = [];
+            foreach ($value as $item) {
+                if ($item !== null && is_object($item)) {
+                    $items[] = $item;
+                }
+            }
+
+            return $items;
+        }
+
+        return [];
+    }
+
+    /**
+     * @param list<object>  $items
+     * @param list<Sorting> $sorting
+     *
+     * @return list<object>
+     */
+    private function applySort(RelationshipMetadata $relationship, array $items, array $sorting): array
+    {
+        if ($sorting === [] || $items === []) {
+            return $items;
+        }
+
+        $metadata = $this->resolveCollectionMetadata($relationship, $items);
+        if ($metadata === null) {
+            return $items;
+        }
+
+        usort($items, function (object $a, object $b) use ($sorting, $metadata): int {
+            foreach ($sorting as $sort) {
+                $result = $this->compare($metadata, $a, $b, $sort);
+                if ($result !== 0) {
+                    return $sort->desc ? -$result : $result;
+                }
+            }
+
+            return 0;
+        });
+
+        return $items;
+    }
+
+    private function compare(ResourceMetadata $metadata, object $a, object $b, Sorting $sorting): int
+    {
+        $path = $this->propertyPathForSort($metadata, $sorting->field);
+        $left = $this->accessor->getValue($a, $path);
+        $right = $this->accessor->getValue($b, $path);
+
+        $left = $this->normalizeSortable($left);
+        $right = $this->normalizeSortable($right);
+
+        return $left <=> $right;
+    }
+
+    private function propertyPathForSort(ResourceMetadata $metadata, string $field): string
+    {
+        if ($field === 'id') {
+            return $metadata->idPropertyPath ?? 'id';
+        }
+
+        if (isset($metadata->attributes[$field])) {
+            return $metadata->attributes[$field]->propertyPath ?? $field;
+        }
+
+        return $field;
+    }
+
+    private function normalizeSortable(mixed $value): mixed
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->getTimestamp();
+        }
+
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        return $value;
+    }
+
+    private function resolveTargetMetadata(RelationshipMetadata $relationship, object $model): ?ResourceMetadata
+    {
+        if ($relationship->targetType !== null) {
+            return $this->registry->getByType($relationship->targetType);
+        }
+
+        return $this->registry->getByClass($model::class);
+    }
+
+    /**
+     * @param list<object> $items
+     */
+    private function resolveCollectionMetadata(RelationshipMetadata $relationship, array $items): ?ResourceMetadata
+    {
+        if ($relationship->targetType !== null) {
+            return $this->registry->getByType($relationship->targetType);
+        }
+
+        $first = $items[0] ?? null;
+        if ($first === null) {
+            return null;
+        }
+
+        return $this->registry->getByClass($first::class);
+    }
+
+    private function resolveId(ResourceMetadata $metadata, object $model): string
+    {
+        $path = $metadata->idPropertyPath ?? 'id';
+        $value = $this->accessor->getValue($model, $path);
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        throw new \RuntimeException(sprintf('Unable to resolve identifier for "%s".', $metadata->type));
+    }
+}

--- a/tests/Fixtures/InMemory/InMemoryRelationshipUpdater.php
+++ b/tests/Fixtures/InMemory/InMemoryRelationshipUpdater.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Fixtures\InMemory;
+
+use JsonApi\Symfony\Contract\Data\RelationshipUpdater;
+use JsonApi\Symfony\Contract\Data\ResourceIdentifier;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Resource\Metadata\RelationshipMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use ReflectionClass;
+use ReflectionException;
+use Stringable;
+
+final class InMemoryRelationshipUpdater implements RelationshipUpdater
+{
+    public function __construct(
+        private readonly ResourceRegistryInterface $registry,
+        private readonly InMemoryRepository $repository,
+    ) {
+    }
+
+    public function replaceToOne(string $type, string $id, string $rel, ?ResourceIdentifier $target): void
+    {
+        $model = $this->requireModel($type, $id);
+        $relationship = $this->requireRelationship($type, $rel);
+        $value = null;
+
+        if ($target !== null) {
+            $value = $this->requireModel($target->type, $target->id);
+        }
+
+        $this->setRelationshipValue($model, $relationship, $value);
+        $this->repository->save($type, $model);
+    }
+
+    /**
+     * @param list<ResourceIdentifier> $targets
+     */
+    public function replaceToMany(string $type, string $id, string $rel, array $targets): void
+    {
+        $model = $this->requireModel($type, $id);
+        $relationship = $this->requireRelationship($type, $rel);
+        $items = [];
+
+        foreach ($targets as $target) {
+            $items[] = $this->requireModel($target->type, $target->id);
+        }
+
+        $this->setRelationshipValue($model, $relationship, $items);
+        $this->repository->save($type, $model);
+    }
+
+    /**
+     * @param list<ResourceIdentifier> $targets
+     */
+    public function addToMany(string $type, string $id, string $rel, array $targets): void
+    {
+        $model = $this->requireModel($type, $id);
+        $relationship = $this->requireRelationship($type, $rel);
+        $current = $this->getRelationshipItems($model, $relationship);
+        $existingMap = $this->mapByIdentifier($current);
+
+        foreach ($targets as $target) {
+            $key = $target->type . ':' . $target->id;
+            if (isset($existingMap[$key])) {
+                continue;
+            }
+
+            $item = $this->requireModel($target->type, $target->id);
+            $existingMap[$key] = $item;
+        }
+
+        $this->setRelationshipValue($model, $relationship, array_values($existingMap));
+        $this->repository->save($type, $model);
+    }
+
+    /**
+     * @param list<ResourceIdentifier> $targets
+     */
+    public function removeFromToMany(string $type, string $id, string $rel, array $targets): void
+    {
+        $model = $this->requireModel($type, $id);
+        $relationship = $this->requireRelationship($type, $rel);
+        $current = $this->getRelationshipItems($model, $relationship);
+        $removeKeys = [];
+
+        foreach ($targets as $target) {
+            $removeKeys[$target->type . ':' . $target->id] = true;
+        }
+
+        $filtered = [];
+        foreach ($current as $item) {
+            $metadata = $this->registry->getByClass($item::class);
+            if ($metadata === null) {
+                continue;
+            }
+
+            $idValue = $this->repository->propertyAccessor()->getValue($item, $metadata->idPropertyPath ?? 'id');
+            $stringId = $this->stringifyId($idValue);
+            if ($stringId === null) {
+                continue;
+            }
+
+            $key = $metadata->type . ':' . $stringId;
+            if (isset($removeKeys[$key])) {
+                continue;
+            }
+
+            $filtered[] = $item;
+        }
+
+        $this->setRelationshipValue($model, $relationship, $filtered);
+        $this->repository->save($type, $model);
+    }
+
+    private function requireModel(string $type, string $id): object
+    {
+        $model = $this->repository->get($type, $id);
+        if ($model === null) {
+            throw new NotFoundException(sprintf('Resource "%s" with id "%s" was not found.', $type, $id));
+        }
+
+        return $model;
+    }
+
+    private function requireRelationship(string $type, string $name): RelationshipMetadata
+    {
+        $metadata = $this->registry->getByType($type);
+        if (!isset($metadata->relationships[$name])) {
+            throw new NotFoundException(sprintf('Relationship "%s" not found on resource "%s".', $name, $type));
+        }
+
+        /** @var RelationshipMetadata $relationship */
+        $relationship = $metadata->relationships[$name];
+
+        return $relationship;
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function getRelationshipItems(object $model, RelationshipMetadata $relationship): array
+    {
+        $value = $this->repository->propertyAccessor()->getValue($model, $relationship->propertyPath ?? $relationship->name);
+
+        if ($value === null) {
+            return [];
+        }
+
+        if (is_array($value)) {
+            return array_values(array_filter($value, static fn ($item) => $item !== null && is_object($item)));
+        }
+
+        if ($value instanceof \Traversable) {
+            $items = [];
+            foreach ($value as $item) {
+                if ($item !== null && is_object($item)) {
+                    $items[] = $item;
+                }
+            }
+
+            return $items;
+        }
+
+        return [];
+    }
+
+    /**
+     * @param list<object> $items
+     *
+     * @return array<string, object>
+     */
+    private function mapByIdentifier(array $items): array
+    {
+        $map = [];
+
+        foreach ($items as $item) {
+            $metadata = $this->registry->getByClass($item::class);
+            if ($metadata === null) {
+                continue;
+            }
+
+            $id = $this->repository->propertyAccessor()->getValue($item, $metadata->idPropertyPath ?? 'id');
+            $stringId = $this->stringifyId($id);
+            if ($stringId === null) {
+                continue;
+            }
+
+            $map[$metadata->type . ':' . $stringId] = $item;
+        }
+
+        return $map;
+    }
+
+    private function setRelationshipValue(object $model, RelationshipMetadata $relationship, mixed $value): void
+    {
+        $property = $relationship->propertyPath ?? $relationship->name;
+
+        try {
+            $reflection = new ReflectionClass($model);
+            if ($reflection->hasProperty($property)) {
+                $prop = $reflection->getProperty($property);
+                $prop->setAccessible(true);
+                $prop->setValue($model, $value);
+
+                return;
+            }
+        } catch (ReflectionException) {
+            // fallback to accessor below
+        }
+
+        $this->repository->propertyAccessor()->setValue($model, $property, $value);
+    }
+
+    private function stringifyId(mixed $value): ?string
+    {
+        if (is_int($value) || is_string($value) || $value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        if (is_float($value)) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+}

--- a/tests/Fixtures/Model/Article.php
+++ b/tests/Fixtures/Model/Article.php
@@ -35,7 +35,7 @@ final class Article
         return $this->createdAt;
     }
 
-    #[Relationship]
+    #[Relationship(targetType: 'authors')]
     public function getAuthor(): Author
     {
         return $this->author;
@@ -44,7 +44,7 @@ final class Article
     /**
      * @return list<Tag>
      */
-    #[Relationship(toMany: true)]
+    #[Relationship(toMany: true, targetType: 'tags')]
     public function getTags(): array
     {
         return $this->tags;

--- a/tests/Functional/CollectionGetTest.php
+++ b/tests/Functional/CollectionGetTest.php
@@ -17,7 +17,8 @@ final class CollectionGetTest extends JsonApiTestCase
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
         self::assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
 
-        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        /** @var array{data: list<array<string, mixed>>, links: array<string, string>, meta: array{total: int, page: int, size: int}} $document */
+        $document = $this->decode($response);
 
         self::assertArrayHasKey('data', $document);
         self::assertCount(15, $document['data']);

--- a/tests/Functional/FieldsTest.php
+++ b/tests/Functional/FieldsTest.php
@@ -16,7 +16,8 @@ final class FieldsTest extends JsonApiTestCase
 
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        /** @var array{data: array{attributes: array<string, mixed>}} $document */
+        $document = $this->decode($response);
 
         self::assertSame(['title'], array_keys($document['data']['attributes']));
     }

--- a/tests/Functional/IncludeTest.php
+++ b/tests/Functional/IncludeTest.php
@@ -16,12 +16,13 @@ final class IncludeTest extends JsonApiTestCase
 
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        /** @var array{included: list<array<string, mixed>>} $document */
+        $document = $this->decode($response);
 
-        self::assertArrayHasKey('included', $document);
-        self::assertCount(3, $document['included']);
+        $included = $document['included'];
+        self::assertCount(3, $included);
 
-        $types = array_column($document['included'], 'type');
+        $types = array_column($included, 'type');
         self::assertContains('authors', $types);
         self::assertContains('tags', $types);
     }

--- a/tests/Functional/JsonApiTestCase.php
+++ b/tests/Functional/JsonApiTestCase.php
@@ -4,30 +4,40 @@ declare(strict_types=1);
 
 namespace JsonApi\Symfony\Tests\Functional;
 
-use JsonApi\Symfony\Contract\Data\ResourceRepository;
 use JsonApi\Symfony\Contract\Data\ResourcePersister;
+use JsonApi\Symfony\Contract\Data\ResourceRepository;
 use JsonApi\Symfony\Contract\Tx\TransactionManager;
 use JsonApi\Symfony\Http\Controller\CollectionController;
 use JsonApi\Symfony\Http\Controller\CreateResourceController;
 use JsonApi\Symfony\Http\Controller\DeleteResourceController;
+use JsonApi\Symfony\Http\Controller\RelatedController;
+use JsonApi\Symfony\Http\Controller\RelationshipGetController;
+use JsonApi\Symfony\Http\Controller\RelationshipWriteController;
 use JsonApi\Symfony\Http\Controller\ResourceController;
 use JsonApi\Symfony\Http\Controller\UpdateResourceController;
 use JsonApi\Symfony\Http\Document\DocumentBuilder;
 use JsonApi\Symfony\Http\Link\LinkGenerator;
+use JsonApi\Symfony\Http\Relationship\LinkageBuilder;
+use JsonApi\Symfony\Http\Relationship\WriteRelationshipsResponseConfig;
 use JsonApi\Symfony\Http\Request\PaginationConfig;
 use JsonApi\Symfony\Http\Request\QueryParser;
 use JsonApi\Symfony\Http\Request\SortingWhitelist;
 use JsonApi\Symfony\Http\Write\ChangeSetFactory;
 use JsonApi\Symfony\Http\Write\InputDocumentValidator;
+use JsonApi\Symfony\Http\Write\RelationshipDocumentValidator;
 use JsonApi\Symfony\Http\Write\WriteConfig;
 use JsonApi\Symfony\Resource\Registry\ResourceRegistry;
 use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
-use JsonApi\Symfony\Tests\Fixtures\InMemory\InMemoryRepository;
+use JsonApi\Symfony\Tests\Fixtures\InMemory\InMemoryExistenceChecker;
 use JsonApi\Symfony\Tests\Fixtures\InMemory\InMemoryPersister;
+use JsonApi\Symfony\Tests\Fixtures\InMemory\InMemoryRelationshipReader;
+use JsonApi\Symfony\Tests\Fixtures\InMemory\InMemoryRelationshipUpdater;
+use JsonApi\Symfony\Tests\Fixtures\InMemory\InMemoryRepository;
 use JsonApi\Symfony\Tests\Fixtures\InMemory\InMemoryTransactionManager;
 use JsonApi\Symfony\Tests\Fixtures\Model\Article;
 use JsonApi\Symfony\Tests\Fixtures\Model\Author;
 use JsonApi\Symfony\Tests\Fixtures\Model\Tag;
+use JsonApi\Symfony\Tests\Util\JsonApiResponseAsserts;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -38,6 +48,8 @@ use Symfony\Component\Routing\RouteCollection;
 
 abstract class JsonApiTestCase extends TestCase
 {
+    use JsonApiResponseAsserts;
+
     private ?ResourceRegistryInterface $registry = null;
     private ?ResourceRepository $repository = null;
     private ?QueryParser $parser = null;
@@ -50,10 +62,15 @@ abstract class JsonApiTestCase extends TestCase
     private ?DeleteResourceController $deleteController = null;
     private ?ResourcePersister $persister = null;
     private ?TransactionManager $transactionManager = null;
+    private ?RelatedController $relatedController = null;
+    private ?RelationshipGetController $relationshipGetController = null;
+    private ?RelationshipWriteController $relationshipWriteController = null;
 
     protected function collectionController(): CollectionController
     {
         $this->boot();
+
+        \assert($this->collectionController instanceof CollectionController);
 
         return $this->collectionController;
     }
@@ -62,12 +79,16 @@ abstract class JsonApiTestCase extends TestCase
     {
         $this->boot();
 
+        \assert($this->resourceController instanceof ResourceController);
+
         return $this->resourceController;
     }
 
     protected function createController(): CreateResourceController
     {
         $this->boot();
+
+        \assert($this->createController instanceof CreateResourceController);
 
         return $this->createController;
     }
@@ -76,6 +97,8 @@ abstract class JsonApiTestCase extends TestCase
     {
         $this->boot();
 
+        \assert($this->updateController instanceof UpdateResourceController);
+
         return $this->updateController;
     }
 
@@ -83,12 +106,43 @@ abstract class JsonApiTestCase extends TestCase
     {
         $this->boot();
 
+        \assert($this->deleteController instanceof DeleteResourceController);
+
         return $this->deleteController;
+    }
+
+    protected function relatedController(): RelatedController
+    {
+        $this->boot();
+
+        \assert($this->relatedController instanceof RelatedController);
+
+        return $this->relatedController;
+    }
+
+    protected function relationshipGetController(): RelationshipGetController
+    {
+        $this->boot();
+
+        \assert($this->relationshipGetController instanceof RelationshipGetController);
+
+        return $this->relationshipGetController;
+    }
+
+    protected function relationshipWriteController(): RelationshipWriteController
+    {
+        $this->boot();
+
+        \assert($this->relationshipWriteController instanceof RelationshipWriteController);
+
+        return $this->relationshipWriteController;
     }
 
     protected function registry(): ResourceRegistryInterface
     {
         $this->boot();
+
+        \assert($this->registry instanceof ResourceRegistryInterface);
 
         return $this->registry;
     }
@@ -97,12 +151,16 @@ abstract class JsonApiTestCase extends TestCase
     {
         $this->boot();
 
+        \assert($this->repository instanceof ResourceRepository);
+
         return $this->repository;
     }
 
     protected function parser(): QueryParser
     {
         $this->boot();
+
+        \assert($this->parser instanceof QueryParser);
 
         return $this->parser;
     }
@@ -111,12 +169,16 @@ abstract class JsonApiTestCase extends TestCase
     {
         $this->boot();
 
+        \assert($this->document instanceof DocumentBuilder);
+
         return $this->document;
     }
 
     protected function propertyAccessor(): PropertyAccessorInterface
     {
         $this->boot();
+
+        \assert($this->accessor instanceof PropertyAccessorInterface);
 
         return $this->accessor;
     }
@@ -125,12 +187,16 @@ abstract class JsonApiTestCase extends TestCase
     {
         $this->boot();
 
+        \assert($this->persister instanceof ResourcePersister);
+
         return $this->persister;
     }
 
     protected function transactionManager(): TransactionManager
     {
         $this->boot();
+
+        \assert($this->transactionManager instanceof TransactionManager);
 
         return $this->transactionManager;
     }
@@ -159,6 +225,9 @@ abstract class JsonApiTestCase extends TestCase
         $routes = new RouteCollection();
         $routes->add('jsonapi.collection', new Route('/api/{type}'));
         $routes->add('jsonapi.resource', new Route('/api/{type}/{id}'));
+        $routes->add('jsonapi.related', new Route('/api/{type}/{id}/{rel}'));
+        $routes->add('jsonapi.relationship.get', new Route('/api/{type}/{id}/relationships/{rel}'));
+        $routes->add('jsonapi.relationship.write', new Route('/api/{type}/{id}/relationships/{rel}'));
 
         $context = new RequestContext();
         $context->setScheme('http');
@@ -167,7 +236,7 @@ abstract class JsonApiTestCase extends TestCase
         $urlGenerator = new UrlGenerator($routes, $context);
         $linkGenerator = new LinkGenerator($urlGenerator);
         $accessor = PropertyAccess::createPropertyAccessor();
-        $document = new DocumentBuilder($registry, $accessor, $linkGenerator);
+        $document = new DocumentBuilder($registry, $accessor, $linkGenerator, 'when_included');
         $repository = new InMemoryRepository($registry, $accessor);
         $writeConfig = new WriteConfig(false, [
             'authors' => true,
@@ -176,6 +245,12 @@ abstract class JsonApiTestCase extends TestCase
         $changeSetFactory = new ChangeSetFactory($registry);
         $persister = new InMemoryPersister($repository, $registry, $accessor);
         $transactionManager = new InMemoryTransactionManager();
+        $relationshipReader = new InMemoryRelationshipReader($registry, $repository, $accessor);
+        $existenceChecker = new InMemoryExistenceChecker($repository);
+        $relationshipUpdater = new InMemoryRelationshipUpdater($registry, $repository);
+        $linkageBuilder = new LinkageBuilder($registry, $relationshipReader, $pagination);
+        $relationshipResponseConfig = new WriteRelationshipsResponseConfig('linkage');
+        $relationshipValidator = new RelationshipDocumentValidator($registry, $existenceChecker);
 
         $this->registry = $registry;
         $this->repository = $repository;
@@ -189,5 +264,8 @@ abstract class JsonApiTestCase extends TestCase
         $this->accessor = $accessor;
         $this->persister = $persister;
         $this->transactionManager = $transactionManager;
+        $this->relatedController = new RelatedController($registry, $relationshipReader, $parser, $document);
+        $this->relationshipGetController = new RelationshipGetController($linkageBuilder);
+        $this->relationshipWriteController = new RelationshipWriteController($relationshipValidator, $relationshipUpdater, $linkageBuilder, $relationshipResponseConfig);
     }
 }

--- a/tests/Functional/Relationships/RelatedGetTest.php
+++ b/tests/Functional/Relationships/RelatedGetTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional\Relationships;
+
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Tests\Functional\JsonApiTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RelatedGetTest extends JsonApiTestCase
+{
+    public function testToOneRelationshipReturnsResource(): void
+    {
+        $request = Request::create('/api/articles/1/author', 'GET');
+        $response = $this->relatedController()($request, 'articles', '1', 'author');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
+
+        /** @var array{data: array{type: string, id: string}} $document */
+        $document = $this->decode($response);
+
+        self::assertSame('authors', $document['data']['type']);
+        self::assertSame('1', $document['data']['id']);
+    }
+
+    public function testToManyRelationshipSupportsPagination(): void
+    {
+        $request = Request::create('/api/articles/1/tags?page[number]=1&page[size]=1', 'GET');
+        $response = $this->relatedController()($request, 'articles', '1', 'tags');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        /** @var array{meta: array{total: int, page: int, size: int}, data: list<array{type: string}>} $document */
+        $document = $this->decode($response);
+
+        self::assertSame(2, $document['meta']['total']);
+        self::assertSame(1, $document['meta']['page']);
+        self::assertSame(1, $document['meta']['size']);
+        self::assertCount(1, $document['data']);
+        self::assertSame('tags', $document['data'][0]['type']);
+    }
+
+    public function testUnknownRelationshipReturnsNotFound(): void
+    {
+        $request = Request::create('/api/articles/1/comments', 'GET');
+
+        $this->expectException(NotFoundException::class);
+        ($this->relatedController())($request, 'articles', '1', 'comments');
+    }
+}

--- a/tests/Functional/Relationships/RelationshipGetTest.php
+++ b/tests/Functional/Relationships/RelationshipGetTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional\Relationships;
+
+use JsonApi\Symfony\Tests\Functional\JsonApiTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RelationshipGetTest extends JsonApiTestCase
+{
+    public function testToOneRelationshipLinkage(): void
+    {
+        $request = Request::create('/api/articles/1/relationships/author', 'GET');
+        $response = $this->relationshipGetController()($request, 'articles', '1', 'author');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        /** @var array{data: array{type: string, id: string}} $document */
+        $document = $this->decode($response);
+
+        self::assertSame(['type' => 'authors', 'id' => '1'], $document['data']);
+    }
+
+    public function testToManyRelationshipLinkageReturnsIdentifiers(): void
+    {
+        $request = Request::create('/api/articles/1/relationships/tags', 'GET');
+        $response = $this->relationshipGetController()($request, 'articles', '1', 'tags');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        /** @var array{data: list<array{type: string, id: string}>} $document */
+        $document = $this->decode($response);
+
+        self::assertCount(2, $document['data']);
+        self::assertSame('tags', $document['data'][0]['type']);
+    }
+}

--- a/tests/Functional/Relationships/RelationshipWriteTest.php
+++ b/tests/Functional/Relationships/RelationshipWriteTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Functional\Relationships;
+
+use JsonApi\Symfony\Http\Exception\ConflictException;
+use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
+use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Tests\Functional\JsonApiTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+
+final class RelationshipWriteTest extends JsonApiTestCase
+{
+    public function testPostToManyAddsIdentifiers(): void
+    {
+        $payload = json_encode([
+            'data' => [
+                ['type' => 'tags', 'id' => '3'],
+                ['type' => 'tags', 'id' => '1'],
+            ],
+        ], \JSON_THROW_ON_ERROR);
+
+        $request = $this->relationshipRequest('POST', '/api/articles/1/relationships/tags', $payload);
+
+        $response = $this->relationshipWriteController()($request, 'articles', '1', 'tags');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        /** @var array{data: list<array{type: string, id: string}>} $document */
+        $document = $this->decode($response);
+        self::assertSame(['tags', 'tags', 'tags'], array_column($document['data'], 'type'));
+        self::assertSame(['1', '2', '3'], array_column($document['data'], 'id'));
+    }
+
+    public function testDeleteToManyRemovesIdentifiers(): void
+    {
+        $payload = json_encode([
+            'data' => [
+                ['type' => 'tags', 'id' => '2'],
+                ['type' => 'tags', 'id' => '4'],
+            ],
+        ], \JSON_THROW_ON_ERROR);
+
+        $request = $this->relationshipRequest('DELETE', '/api/articles/1/relationships/tags', $payload);
+
+        $response = $this->relationshipWriteController()($request, 'articles', '1', 'tags');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        /** @var array{data: list<array{type: string, id: string}>} $document */
+        $document = $this->decode($response);
+        self::assertSame(['1'], array_column($document['data'], 'id'));
+    }
+
+    public function testPatchToManyReplacesIdentifiers(): void
+    {
+        $payload = json_encode([
+            'data' => [
+                ['type' => 'tags', 'id' => '3'],
+                ['type' => 'tags', 'id' => '4'],
+            ],
+        ], \JSON_THROW_ON_ERROR);
+
+        $request = $this->relationshipRequest('PATCH', '/api/articles/1/relationships/tags', $payload);
+
+        $response = $this->relationshipWriteController()($request, 'articles', '1', 'tags');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        /** @var array{data: list<array{type: string, id: string}>} $document */
+        $document = $this->decode($response);
+        self::assertSame(['3', '4'], array_column($document['data'], 'id'));
+    }
+
+    public function testPatchToOneUpdatesRelationship(): void
+    {
+        $payload = json_encode([
+            'data' => ['type' => 'authors', 'id' => '2'],
+        ], \JSON_THROW_ON_ERROR);
+
+        $request = $this->relationshipRequest('PATCH', '/api/articles/1/relationships/author', $payload);
+
+        $response = $this->relationshipWriteController()($request, 'articles', '1', 'author');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        /** @var array{data: array{type: string, id: string}} $document */
+        $document = $this->decode($response);
+        self::assertSame(['type' => 'authors', 'id' => '2'], $document['data']);
+    }
+
+    public function testPatchToOneNullWhenNotNullableReturnsConflict(): void
+    {
+        $payload = json_encode([
+            'data' => null,
+        ], \JSON_THROW_ON_ERROR);
+
+        $request = $this->relationshipRequest('PATCH', '/api/articles/1/relationships/author', $payload);
+        $this->expectException(ConflictException::class);
+        ($this->relationshipWriteController())($request, 'articles', '1', 'author');
+    }
+
+    public function testPostToOneReturnsMethodNotAllowed(): void
+    {
+        $payload = json_encode([
+            'data' => ['type' => 'authors', 'id' => '2'],
+        ], \JSON_THROW_ON_ERROR);
+
+        $request = $this->relationshipRequest('POST', '/api/articles/1/relationships/author', $payload);
+        $this->expectException(MethodNotAllowedHttpException::class);
+        ($this->relationshipWriteController())($request, 'articles', '1', 'author');
+    }
+
+    public function testMismatchedTypeCausesConflict(): void
+    {
+        $payload = json_encode([
+            'data' => [
+                ['type' => 'authors', 'id' => '1'],
+            ],
+        ], \JSON_THROW_ON_ERROR);
+
+        $request = $this->relationshipRequest('PATCH', '/api/articles/1/relationships/tags', $payload);
+
+        $this->expectException(ConflictException::class);
+        ($this->relationshipWriteController())($request, 'articles', '1', 'tags');
+    }
+
+    public function testUnknownIdentifierReturnsNotFound(): void
+    {
+        $payload = json_encode([
+            'data' => [
+                ['type' => 'tags', 'id' => '999'],
+            ],
+        ], \JSON_THROW_ON_ERROR);
+
+        $request = $this->relationshipRequest('POST', '/api/articles/1/relationships/tags', $payload);
+
+        $this->expectException(NotFoundException::class);
+        ($this->relationshipWriteController())($request, 'articles', '1', 'tags');
+    }
+
+    public function testUnsupportedContentTypeReturnsError(): void
+    {
+        $request = Request::create(
+            '/api/articles/1/relationships/tags',
+            'PATCH',
+            server: ['CONTENT_TYPE' => 'text/plain'],
+            content: '{}'
+        );
+
+        $this->expectException(JsonApiHttpException::class);
+        ($this->relationshipWriteController())($request, 'articles', '1', 'tags');
+    }
+
+    private function relationshipRequest(string $method, string $uri, string $payload): Request
+    {
+        return Request::create(
+            $uri,
+            $method,
+            server: ['CONTENT_TYPE' => 'application/vnd.api+json'],
+            content: $payload,
+        );
+    }
+}

--- a/tests/Functional/ResourceGetTest.php
+++ b/tests/Functional/ResourceGetTest.php
@@ -17,7 +17,18 @@ final class ResourceGetTest extends JsonApiTestCase
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
         self::assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
 
-        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        /** @var array{
+         *     data: array{
+         *         type: string,
+         *         id: string,
+         *         attributes: array<string, mixed>,
+         *         links: array<string, string>,
+         *         relationships: array<string, array<string, mixed>>
+         *     },
+         *     links: array<string, string>
+         * } $document
+         */
+        $document = $this->decode($response);
 
         self::assertSame('articles', $document['data']['type']);
         self::assertSame('1', $document['data']['id']);
@@ -25,5 +36,30 @@ final class ResourceGetTest extends JsonApiTestCase
         self::assertArrayHasKey('createdAt', $document['data']['attributes']);
         self::assertSame('http://localhost/api/articles/1', $document['data']['links']['self']);
         self::assertSame('http://localhost/api/articles/1', $document['links']['self']);
+        $data = $document['data'];
+        self::assertArrayHasKey('relationships', $data);
+        $relationships = $data['relationships'];
+        self::assertArrayHasKey('author', $relationships);
+        /** @var array<string, mixed> $authorRelationship */
+        $authorRelationship = $relationships['author'];
+        self::assertArrayHasKey('links', $authorRelationship);
+        /** @var array<string, string> $relationshipLinks */
+        $relationshipLinks = $authorRelationship['links'];
+        self::assertArrayHasKey('self', $relationshipLinks);
+        self::assertArrayHasKey('related', $relationshipLinks);
+        self::assertArrayNotHasKey('data', $authorRelationship);
+    }
+
+    public function testRelationshipLinkageIncludedWhenRequested(): void
+    {
+        $request = Request::create('/api/articles/1', 'GET', ['include' => 'author']);
+        $response = ($this->resourceController())($request, 'articles', '1');
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        /** @var array{data: array{relationships: array<string, array<string, mixed>>}} $document */
+        $document = $this->decode($response);
+
+        self::assertSame(['type' => 'authors', 'id' => '1'], $document['data']['relationships']['author']['data']);
     }
 }

--- a/tests/Functional/ResourceWriteTest.php
+++ b/tests/Functional/ResourceWriteTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace JsonApi\Symfony\Tests\Functional;
 
-use JsonApi\Symfony\Http\Negotiation\MediaType;
 use JsonApi\Symfony\Http\Exception\BadRequestException;
 use JsonApi\Symfony\Http\Exception\ConflictException;
 use JsonApi\Symfony\Http\Exception\ForbiddenException;
 use JsonApi\Symfony\Http\Exception\JsonApiHttpException;
 use JsonApi\Symfony\Http\Exception\NotFoundException;
+use JsonApi\Symfony\Http\Negotiation\MediaType;
 use JsonApi\Symfony\Query\Criteria;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -33,7 +33,8 @@ final class ResourceWriteTest extends JsonApiTestCase
         self::assertSame(201, $response->getStatusCode());
         self::assertSame(MediaType::JSON_API, $response->headers->get('Content-Type'));
 
-        $document = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+        /** @var array{data: array{id: string, type: string, attributes: array<string, mixed>, links: array<string, string>}} $document */
+        $document = $this->decode($response);
         $id = $document['data']['id'];
 
         self::assertNotEmpty($id);
@@ -61,7 +62,8 @@ final class ResourceWriteTest extends JsonApiTestCase
 
         self::assertSame(201, $response->getStatusCode());
 
-        $document = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+        /** @var array{data: array{id: string, attributes: array<string, mixed>}} $document */
+        $document = $this->decode($response);
         self::assertSame('author-123', $document['data']['id']);
         self::assertSame('Client Author', $document['data']['attributes']['name']);
 
@@ -85,7 +87,8 @@ final class ResourceWriteTest extends JsonApiTestCase
 
         self::assertSame(200, $response->getStatusCode());
 
-        $document = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+        /** @var array{data: array{attributes: array<string, mixed>}} $document */
+        $document = $this->decode($response);
         self::assertSame('Updated title', $document['data']['attributes']['title']);
     }
 
@@ -214,7 +217,7 @@ final class ResourceWriteTest extends JsonApiTestCase
 
     public function testUnsupportedMediaTypeResultsIn415(): void
     {
-        $payload = json_encode(['data' => ['type' => 'articles', 'attributes' => ['title' => 'Invalid']]], JSON_THROW_ON_ERROR);
+        $payload = json_encode(['data' => ['type' => 'articles', 'attributes' => ['title' => 'Invalid']]], \JSON_THROW_ON_ERROR);
         $request = Request::create('/api/articles', 'POST', server: ['CONTENT_TYPE' => 'application/json'], content: $payload);
 
         $this->expectException(JsonApiHttpException::class);
@@ -230,7 +233,7 @@ final class ResourceWriteTest extends JsonApiTestCase
                 'CONTENT_TYPE' => MediaType::JSON_API,
                 'HTTP_ACCEPT' => MediaType::JSON_API,
             ],
-            content: json_encode([['type' => 'articles']], JSON_THROW_ON_ERROR),
+            content: json_encode([['type' => 'articles']], \JSON_THROW_ON_ERROR),
         );
 
         $this->expectException(BadRequestException::class);
@@ -246,7 +249,7 @@ final class ResourceWriteTest extends JsonApiTestCase
                 'CONTENT_TYPE' => MediaType::JSON_API,
                 'HTTP_ACCEPT' => MediaType::JSON_API,
             ],
-            content: json_encode([['type' => 'articles']], JSON_THROW_ON_ERROR),
+            content: json_encode([['type' => 'articles']], \JSON_THROW_ON_ERROR),
         );
 
         $this->expectException(BadRequestException::class);
@@ -258,7 +261,7 @@ final class ResourceWriteTest extends JsonApiTestCase
      */
     private function jsonRequest(string $method, string $uri, array $payload): Request
     {
-        $json = json_encode($payload, JSON_THROW_ON_ERROR);
+        $json = json_encode($payload, \JSON_THROW_ON_ERROR);
 
         return Request::create(
             $uri,

--- a/tests/Functional/SortAndPageTest.php
+++ b/tests/Functional/SortAndPageTest.php
@@ -20,7 +20,8 @@ final class SortAndPageTest extends JsonApiTestCase
 
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $document = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        /** @var array{data: list<array<string, mixed>>, links: array<string, string>} $document */
+        $document = $this->decode($response);
 
         self::assertCount(5, $document['data']);
         self::assertSame('10', $document['data'][0]['id']);

--- a/tests/Unit/Http/Relationship/LinkageBuilderTest.php
+++ b/tests/Unit/Http/Relationship/LinkageBuilderTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Unit\Http\Relationship;
+
+use BadMethodCallException;
+use JsonApi\Symfony\Contract\Data\RelationshipReader;
+use JsonApi\Symfony\Contract\Data\Slice;
+use JsonApi\Symfony\Contract\Data\SliceIds;
+use JsonApi\Symfony\Http\Relationship\LinkageBuilder;
+use JsonApi\Symfony\Http\Request\PaginationConfig;
+use JsonApi\Symfony\Query\Criteria;
+use JsonApi\Symfony\Resource\Metadata\RelationshipMetadata;
+use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
+use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class LinkageBuilderTest extends TestCase
+{
+    public function testResolvesTargetTypeFromTargetClassMetadata(): void
+    {
+        $articleMetadata = new ResourceMetadata(
+            'articles',
+            ArticleResource::class,
+            [],
+            [
+                'author' => new RelationshipMetadata('author', false, null, null, AuthorResource::class, false),
+            ],
+        );
+
+        $authorMetadata = new ResourceMetadata('people', AuthorResource::class, [], []);
+
+        $registry = new class($articleMetadata, $authorMetadata) implements ResourceRegistryInterface {
+            public function __construct(
+                private ResourceMetadata $article,
+                private ResourceMetadata $author,
+            ) {
+            }
+
+            public function getByType(string $type): ResourceMetadata
+            {
+                return match ($type) {
+                    'articles' => $this->article,
+                    'people' => $this->author,
+                    default => throw new \LogicException(sprintf('Unknown resource type "%s".', $type)),
+                };
+            }
+
+            public function hasType(string $type): bool
+            {
+                return in_array($type, ['articles', 'people'], true);
+            }
+
+            public function getByClass(string $class): ?ResourceMetadata
+            {
+                return match ($class) {
+                    ArticleResource::class => $this->article,
+                    AuthorResource::class => $this->author,
+                    default => null,
+                };
+            }
+        };
+
+        $reader = new class implements RelationshipReader {
+            public function getToOneId(string $type, string $id, string $rel): ?string
+            {
+                return $rel === 'author' ? '1' : null;
+            }
+
+            public function getToManyIds(string $type, string $id, string $rel, \JsonApi\Symfony\Query\Pagination $pagination): SliceIds
+            {
+                throw new BadMethodCallException('Not implemented.');
+            }
+
+            public function getRelatedResource(string $type, string $id, string $rel): ?object
+            {
+                return null;
+            }
+
+            public function getRelatedCollection(string $type, string $id, string $rel, Criteria $criteria): Slice
+            {
+                throw new BadMethodCallException('Not implemented.');
+            }
+        };
+
+        $builder = new LinkageBuilder($registry, $reader, new PaginationConfig());
+
+        [$kind, $data] = $builder->read('articles', '1', 'author', new Request());
+
+        self::assertSame('to-one', $kind);
+        self::assertSame(['type' => 'people', 'id' => '1'], $data);
+    }
+
+    public function testFallsBackToRelationshipNameWhenTypeIsRegistered(): void
+    {
+        $articleMetadata = new ResourceMetadata(
+            'articles',
+            ArticleResource::class,
+            [],
+            [
+                'comments' => new RelationshipMetadata('comments'),
+            ],
+        );
+
+        $commentMetadata = new ResourceMetadata('comments', CommentResource::class, [], []);
+
+        $registry = new class($articleMetadata, $commentMetadata) implements ResourceRegistryInterface {
+            public function __construct(
+                private ResourceMetadata $article,
+                private ResourceMetadata $comment,
+            ) {
+            }
+
+            public function getByType(string $type): ResourceMetadata
+            {
+                return match ($type) {
+                    'articles' => $this->article,
+                    'comments' => $this->comment,
+                    default => throw new \LogicException(sprintf('Unknown resource type "%s".', $type)),
+                };
+            }
+
+            public function hasType(string $type): bool
+            {
+                return in_array($type, ['articles', 'comments'], true);
+            }
+
+            public function getByClass(string $class): ?ResourceMetadata
+            {
+                return match ($class) {
+                    ArticleResource::class => $this->article,
+                    CommentResource::class => $this->comment,
+                    default => null,
+                };
+            }
+        };
+
+        $reader = new class implements RelationshipReader {
+            public function getToOneId(string $type, string $id, string $rel): ?string
+            {
+                return $rel === 'comments' ? '2' : null;
+            }
+
+            public function getToManyIds(string $type, string $id, string $rel, \JsonApi\Symfony\Query\Pagination $pagination): SliceIds
+            {
+                throw new BadMethodCallException('Not implemented.');
+            }
+
+            public function getRelatedResource(string $type, string $id, string $rel): ?object
+            {
+                return null;
+            }
+
+            public function getRelatedCollection(string $type, string $id, string $rel, Criteria $criteria): Slice
+            {
+                throw new BadMethodCallException('Not implemented.');
+            }
+        };
+
+        $builder = new LinkageBuilder($registry, $reader, new PaginationConfig());
+
+        [$kind, $data] = $builder->read('articles', '1', 'comments', new Request());
+
+        self::assertSame('to-one', $kind);
+        self::assertSame(['type' => 'comments', 'id' => '2'], $data);
+    }
+}
+
+final class ArticleResource
+{
+}
+
+final class AuthorResource
+{
+}
+
+final class CommentResource
+{
+}

--- a/tests/Util/JsonApiResponseAsserts.php
+++ b/tests/Util/JsonApiResponseAsserts.php
@@ -6,16 +6,27 @@ namespace JsonApi\Symfony\Tests\Util;
 
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 trait JsonApiResponseAsserts
 {
     /**
      * @return array<string, mixed>
      */
-    protected function decode(JsonResponse $response): array
+    protected function decode(Response $response): array
     {
+        Assert::assertInstanceOf(JsonResponse::class, $response);
         Assert::assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
 
-        return json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        /** @var JsonResponse $jsonResponse */
+        $jsonResponse = $response;
+
+        $decoded = json_decode((string) $jsonResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        if (!is_array($decoded)) {
+            Assert::fail('Expected JSON:API document to decode to an array.');
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
     }
 }


### PR DESCRIPTION
## Summary
- implement related resource and relationship linkage controllers with validation, linkage serialization, and configurable responses
- extend metadata, configuration, and in-memory adapters to expose relationship linkage and enforce target types
- update document builder, helpers, and functional coverage for relationship links and JSON:API negotiation behaviors

## Testing
- make cs-fix
- vendor/bin/phpstan analyse --memory-limit=512M
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e2d740c3c0832faf81747db173f7c0