### PR TITLE
Add scaffolding for Stage 5 filter components

### DIFF
--- a/src/Filter/Ast/Between.php
+++ b/src/Filter/Ast/Between.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Ast;
+
+/**
+ * Represents a BETWEEN comparison.
+ */
+final class Between implements Node
+{
+    public function __construct(
+        public readonly string $fieldPath,
+        public readonly mixed $from,
+        public readonly mixed $to,
+    ) {
+    }
+}

--- a/src/Filter/Ast/Comparison.php
+++ b/src/Filter/Ast/Comparison.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Ast;
+
+/**
+ * Represents a primitive comparison like eq, lt, etc.
+ */
+final class Comparison implements Node
+{
+    public function __construct(
+        public readonly string $fieldPath,
+        public readonly string $operator,
+        /** @var list<mixed> */
+        public readonly array $values,
+    ) {
+    }
+}

--- a/src/Filter/Ast/Conjunction.php
+++ b/src/Filter/Ast/Conjunction.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Ast;
+
+/**
+ * Represents an AND node combining child filters.
+ */
+final class Conjunction implements Node
+{
+    /**
+     * @param list<Node> $children
+     */
+    public function __construct(
+        public readonly array $children,
+    ) {
+    }
+}

--- a/src/Filter/Ast/Disjunction.php
+++ b/src/Filter/Ast/Disjunction.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Ast;
+
+/**
+ * Represents an OR node combining child filters.
+ */
+final class Disjunction implements Node
+{
+    /**
+     * @param list<Node> $children
+     */
+    public function __construct(
+        public readonly array $children,
+    ) {
+    }
+}

--- a/src/Filter/Ast/Group.php
+++ b/src/Filter/Ast/Group.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Ast;
+
+/**
+ * Represents a grouped sub-expression, preserving explicit parentheses.
+ */
+final class Group implements Node
+{
+    public function __construct(
+        public readonly Node $expression,
+    ) {
+    }
+}

--- a/src/Filter/Ast/Node.php
+++ b/src/Filter/Ast/Node.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Ast;
+
+/**
+ * Marker interface for filter AST nodes.
+ */
+interface Node
+{
+}

--- a/src/Filter/Ast/NullCheck.php
+++ b/src/Filter/Ast/NullCheck.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Ast;
+
+/**
+ * Represents an IS NULL / IS NOT NULL check.
+ */
+final class NullCheck implements Node
+{
+    public function __construct(
+        public readonly string $fieldPath,
+        public readonly bool $isNull,
+    ) {
+    }
+}

--- a/src/Filter/Compiler/Doctrine/DoctrineFilterCompiler.php
+++ b/src/Filter/Compiler/Doctrine/DoctrineFilterCompiler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Compiler\Doctrine;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\QueryBuilder;
+use JsonApi\Symfony\Filter\Ast\Node;
+use JsonApi\Symfony\Filter\Operator\Registry;
+
+/**
+ * Compiles filter ASTs into Doctrine ORM QueryBuilder expressions.
+ */
+final class DoctrineFilterCompiler
+{
+    public function __construct(
+        private readonly Registry $operators,
+    ) {
+    }
+
+    public function apply(QueryBuilder $qb, Node $ast, AbstractPlatform $platform): void
+    {
+        // Proper compilation will be implemented in a future iteration. The
+        // method signature is already in place so collaborators can rely on it.
+    }
+}

--- a/src/Filter/Compiler/Doctrine/JoinManager.php
+++ b/src/Filter/Compiler/Doctrine/JoinManager.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Compiler\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Minimal join manager stub. Ensures structure exists for future logic.
+ */
+final class JoinManager
+{
+    public function __construct(
+        private readonly QueryBuilder $qb,
+    ) {
+    }
+
+    public function resolveAlias(string $fieldPath): string
+    {
+        // TODO: add join resolution logic once metadata integration lands.
+        return $this->qb->getRootAliases()[0] ?? 'root';
+    }
+}

--- a/src/Filter/Family/Family.php
+++ b/src/Filter/Family/Family.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Family;
+
+use JsonApi\Symfony\Filter\Ast\Node;
+
+interface Family
+{
+    /**
+     * @param array<string, mixed> $raw
+     */
+    public function build(array $raw): ?Node;
+}

--- a/src/Filter/Family/SearchFamily.php
+++ b/src/Filter/Family/SearchFamily.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Family;
+
+use JsonApi\Symfony\Filter\Ast\Node;
+
+final class SearchFamily implements Family
+{
+    public function __construct(
+        private readonly array $fields,
+    ) {
+    }
+
+    public function build(array $raw): ?Node
+    {
+        // Placeholder implementation; proper full-text expansion to follow.
+        return null;
+    }
+}

--- a/src/Filter/Operator/AbstractOperator.php
+++ b/src/Filter/Operator/AbstractOperator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
+
+/**
+ * Shared defaults for operator implementations.
+ */
+abstract class AbstractOperator implements Operator
+{
+    public function supportsField(ResourceMetadata $meta, string $fieldPath): bool
+    {
+        // Proper whitelist handling will arrive with the full implementation.
+        return true;
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    public function normalizeValues(mixed $raw): array
+    {
+        return is_array($raw) ? array_values($raw) : [$raw];
+    }
+}

--- a/src/Filter/Operator/BetweenOperator.php
+++ b/src/Filter/Operator/BetweenOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class BetweenOperator extends AbstractOperator
+{
+    public function name(): string
+    {
+        return 'between';
+    }
+
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression {
+        throw new \LogicException('BetweenOperator compilation is not implemented yet.');
+    }
+}

--- a/src/Filter/Operator/EqualOperator.php
+++ b/src/Filter/Operator/EqualOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class EqualOperator extends AbstractOperator
+{
+    public function name(): string
+    {
+        return 'eq';
+    }
+
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression {
+        throw new \LogicException('EqualOperator compilation is not implemented yet.');
+    }
+}

--- a/src/Filter/Operator/GreaterOrEqualOperator.php
+++ b/src/Filter/Operator/GreaterOrEqualOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class GreaterOrEqualOperator extends AbstractOperator
+{
+    public function name(): string
+    {
+        return 'gte';
+    }
+
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression {
+        throw new \LogicException('GreaterOrEqualOperator compilation is not implemented yet.');
+    }
+}

--- a/src/Filter/Operator/GreaterThanOperator.php
+++ b/src/Filter/Operator/GreaterThanOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class GreaterThanOperator extends AbstractOperator
+{
+    public function name(): string
+    {
+        return 'gt';
+    }
+
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression {
+        throw new \LogicException('GreaterThanOperator compilation is not implemented yet.');
+    }
+}

--- a/src/Filter/Operator/InOperator.php
+++ b/src/Filter/Operator/InOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class InOperator extends AbstractOperator
+{
+    public function name(): string
+    {
+        return 'in';
+    }
+
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression {
+        throw new \LogicException('InOperator compilation is not implemented yet.');
+    }
+}

--- a/src/Filter/Operator/IsNullOperator.php
+++ b/src/Filter/Operator/IsNullOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class IsNullOperator extends AbstractOperator
+{
+    public function name(): string
+    {
+        return 'isnull';
+    }
+
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression {
+        throw new \LogicException('IsNullOperator compilation is not implemented yet.');
+    }
+}

--- a/src/Filter/Operator/LessOrEqualOperator.php
+++ b/src/Filter/Operator/LessOrEqualOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class LessOrEqualOperator extends AbstractOperator
+{
+    public function name(): string
+    {
+        return 'lte';
+    }
+
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression {
+        throw new \LogicException('LessOrEqualOperator compilation is not implemented yet.');
+    }
+}

--- a/src/Filter/Operator/LessThanOperator.php
+++ b/src/Filter/Operator/LessThanOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class LessThanOperator extends AbstractOperator
+{
+    public function name(): string
+    {
+        return 'lt';
+    }
+
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression {
+        throw new \LogicException('LessThanOperator compilation is not implemented yet.');
+    }
+}

--- a/src/Filter/Operator/LikeOperator.php
+++ b/src/Filter/Operator/LikeOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class LikeOperator extends AbstractOperator
+{
+    public function name(): string
+    {
+        return 'like';
+    }
+
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression {
+        throw new \LogicException('LikeOperator compilation is not implemented yet.');
+    }
+}

--- a/src/Filter/Operator/NotEqualOperator.php
+++ b/src/Filter/Operator/NotEqualOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+final class NotEqualOperator extends AbstractOperator
+{
+    public function name(): string
+    {
+        return 'neq';
+    }
+
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression {
+        throw new \LogicException('NotEqualOperator compilation is not implemented yet.');
+    }
+}

--- a/src/Filter/Operator/Operator.php
+++ b/src/Filter/Operator/Operator.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
+
+/**
+ * Contract implemented by filter operators.
+ */
+interface Operator
+{
+    public function name(): string;
+
+    public function supportsField(ResourceMetadata $meta, string $fieldPath): bool;
+
+    /**
+     * Normalise the raw value(s) provided by the client.
+     *
+     * @return list<mixed>
+     */
+    public function normalizeValues(mixed $raw): array;
+
+    /**
+     * Compile a comparison node into a Doctrine expression fragment.
+     */
+    public function compile(
+        string $rootAlias,
+        string $dqlField,
+        array $values,
+        AbstractPlatform $platform,
+    ): DoctrineExpression;
+}
+
+/**
+ * Lightweight value object carrying the compiled DQL and bound parameters.
+ */
+final class DoctrineExpression
+{
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function __construct(
+        public readonly string $dql,
+        public readonly array $parameters,
+    ) {
+    }
+}

--- a/src/Filter/Operator/Registry.php
+++ b/src/Filter/Operator/Registry.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Operator;
+
+/**
+ * Simple in-memory operator registry.
+ */
+final class Registry
+{
+    /** @var array<string, Operator> */
+    private array $operators = [];
+
+    public function register(Operator $operator): void
+    {
+        $this->operators[$operator->name()] = $operator;
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->operators[$name]);
+    }
+
+    public function get(string $name): Operator
+    {
+        if (!$this->has($name)) {
+            throw new \InvalidArgumentException(sprintf('Unknown operator "%s".', $name));
+        }
+
+        return $this->operators[$name];
+    }
+
+    /**
+     * @return list<Operator>
+     */
+    public function all(): array
+    {
+        return array_values($this->operators);
+    }
+}

--- a/src/Filter/Parser/FieldPath.php
+++ b/src/Filter/Parser/FieldPath.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Parser;
+
+/**
+ * Represents a dotted field path like "author.name".
+ */
+final class FieldPath
+{
+    /** @var list<string> */
+    private array $segments;
+
+    public function __construct(string $path)
+    {
+        $trimmed = trim($path);
+        if ($trimmed === '') {
+            throw new \InvalidArgumentException('Field path cannot be empty.');
+        }
+
+        $this->segments = explode('.', $trimmed);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function segments(): array
+    {
+        return $this->segments;
+    }
+
+    public function __toString(): string
+    {
+        return implode('.', $this->segments);
+    }
+}

--- a/src/Filter/Parser/FilterParser.php
+++ b/src/Filter/Parser/FilterParser.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Parser;
+
+use JsonApi\Symfony\Filter\Ast\Node;
+
+/**
+ * Skeleton filter parser responsible for turning query parameters into an AST.
+ *
+ * The full Stage 5 implementation will introduce a proper grammar. For now
+ * this class only stores the raw filter payload for later interpretation.
+ */
+final class FilterParser
+{
+    /**
+     * @param array<string, mixed> $rawFilters
+     */
+    public function parse(array $rawFilters): ?Node
+    {
+        // The complete parsing logic will arrive in a later commit. Keeping the
+        // method signature allows downstream code to type-hint against it.
+        return null;
+    }
+}

--- a/src/Filter/Parser/FilterParser.php
+++ b/src/Filter/Parser/FilterParser.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace JsonApi\Symfony\Filter\Parser;
 
+use JsonApi\Symfony\Filter\Ast\Between;
+use JsonApi\Symfony\Filter\Ast\Comparison;
+use JsonApi\Symfony\Filter\Ast\Conjunction;
+use JsonApi\Symfony\Filter\Ast\Disjunction;
 use JsonApi\Symfony\Filter\Ast\Node;
+use JsonApi\Symfony\Filter\Ast\NullCheck;
 
 /**
- * Skeleton filter parser responsible for turning query parameters into an AST.
+ * Heuristic filter parser responsible for turning query parameters into an AST.
  *
- * The full Stage 5 implementation will introduce a proper grammar. For now
- * this class only stores the raw filter payload for later interpretation.
+ * A dedicated grammar will arrive alongside the full Stage 5 implementation.
+ * Until then the parser recognises a pragmatic subset of the JSON:API filter
+ * dialect so consumers can begin exercising the downstream components.
  */
 final class FilterParser
 {
@@ -19,8 +25,202 @@ final class FilterParser
      */
     public function parse(array $rawFilters): ?Node
     {
-        // The complete parsing logic will arrive in a later commit. Keeping the
-        // method signature allows downstream code to type-hint against it.
-        return null;
+        return $this->parseGroup($rawFilters);
+    }
+
+    /**
+     * @param array<string, mixed> $raw
+     */
+    private function parseGroup(array $raw): ?Node
+    {
+        $nodes = [];
+
+        foreach ($raw as $key => $value) {
+            if ($key === 'and') {
+                $node = $this->parseLogicalGroup($value, true);
+            } elseif ($key === 'or') {
+                $node = $this->parseLogicalGroup($value, false);
+            } elseif (is_string($key)) {
+                $node = $this->parseFieldComparisons($key, $value);
+            } else {
+                throw new \InvalidArgumentException(sprintf('Invalid filter key type "%s".', get_debug_type($key)));
+            }
+
+            if ($node !== null) {
+                $nodes[] = $node;
+            }
+        }
+
+        if ($nodes === []) {
+            return null;
+        }
+
+        if (count($nodes) === 1) {
+            return $nodes[0];
+        }
+
+        return new Conjunction($nodes);
+    }
+
+    private function parseLogicalGroup(mixed $raw, bool $isAnd): ?Node
+    {
+        if (!is_array($raw)) {
+            throw new \InvalidArgumentException(sprintf('Logical group must be an array, "%s" given.', get_debug_type($raw)));
+        }
+
+        if (!$this->isList($raw)) {
+            throw new \InvalidArgumentException('Logical groups must be provided as a list of filter objects.');
+        }
+
+        $children = [];
+
+        foreach ($raw as $index => $childRaw) {
+            if (!is_array($childRaw)) {
+                throw new \InvalidArgumentException(sprintf('Logical group entry at index %s must be an array, "%s" given.', (string) $index, get_debug_type($childRaw)));
+            }
+
+            $node = $this->parseGroup($childRaw);
+
+            if ($node !== null) {
+                $children[] = $node;
+            }
+        }
+
+        if ($children === []) {
+            return null;
+        }
+
+        return $isAnd ? new Conjunction($children) : new Disjunction($children);
+    }
+
+    private function parseFieldComparisons(string $fieldPath, mixed $raw): ?Node
+    {
+        $field = (string) new FieldPath($fieldPath);
+
+        $nodes = [];
+
+        if ($raw === null) {
+            $nodes[] = new NullCheck($field, true);
+        } elseif (!is_array($raw)) {
+            $nodes[] = new Comparison($field, 'eq', [$raw]);
+        } elseif ($raw === []) {
+            return null;
+        } elseif ($this->isList($raw)) {
+            if ($raw !== []) {
+                $nodes[] = new Comparison($field, 'in', array_values($raw));
+            }
+        } else {
+            foreach ($raw as $operator => $value) {
+                if (!is_string($operator)) {
+                    throw new \InvalidArgumentException('Filter operators must be identified by strings.');
+                }
+
+                $nodes = array_merge($nodes, $this->parseOperator($field, $operator, $value));
+            }
+        }
+
+        if ($nodes === []) {
+            return null;
+        }
+
+        if (count($nodes) === 1) {
+            return $nodes[0];
+        }
+
+        return new Conjunction($nodes);
+    }
+
+    /**
+     * @return list<Node>
+     */
+    private function parseOperator(string $field, string $operator, mixed $value): array
+    {
+        switch ($operator) {
+            case 'eq':
+            case 'ne':
+            case 'lt':
+            case 'lte':
+            case 'gt':
+            case 'gte':
+            case 'like':
+                return [new Comparison($field, $operator, $this->normalizeValues($value))];
+            case 'in':
+                $values = $this->normalizeValues($value);
+
+                if ($values === []) {
+                    return [];
+                }
+
+                return [new Comparison($field, $operator, $values)];
+            case 'between':
+                if (!is_array($value)) {
+                    throw new \InvalidArgumentException('The "between" operator expects an array.');
+                }
+
+                if ($this->isAssoc($value)) {
+                    if (!array_key_exists('from', $value) || !array_key_exists('to', $value)) {
+                        throw new \InvalidArgumentException('The "between" operator expects "from" and "to" keys.');
+                    }
+
+                    return [new Between($field, $value['from'], $value['to'])];
+                }
+
+                $values = array_values($value);
+
+                if (count($values) < 2) {
+                    throw new \InvalidArgumentException('The "between" operator expects exactly two values.');
+                }
+
+                return [new Between($field, $values[0], $values[1])];
+            case 'isnull':
+                return [new NullCheck($field, $this->toBool($value))];
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unsupported operator "%s".', $operator));
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function normalizeValues(mixed $raw): array
+    {
+        if ($raw instanceof \Traversable) {
+            $raw = iterator_to_array($raw, false);
+        }
+
+        return is_array($raw) ? array_values($raw) : [$raw];
+    }
+
+    private function toBool(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value === 1;
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower($value);
+
+            return in_array($normalized, ['1', 'true', 'yes'], true);
+        }
+
+        return (bool) $value;
+    }
+
+    private function isList(array $value): bool
+    {
+        if ($value === []) {
+            return true;
+        }
+
+        return array_keys($value) === range(0, count($value) - 1);
+    }
+
+    private function isAssoc(array $value): bool
+    {
+        return !$this->isList($value);
     }
 }

--- a/src/Filter/Validation/FilterLimits.php
+++ b/src/Filter/Validation/FilterLimits.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Validation;
+
+final class FilterLimits
+{
+    public function __construct(
+        public readonly int $maxClauses,
+        public readonly int $maxDepth,
+        public readonly int $maxInValues,
+    ) {
+    }
+}

--- a/src/Filter/Validation/FilterWhitelist.php
+++ b/src/Filter/Validation/FilterWhitelist.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Filter\Validation;
+
+/**
+ * Value object describing which fields/operators are allowed per resource type.
+ */
+final class FilterWhitelist
+{
+    /**
+     * @param array<string, array<string, list<string>>> $whitelist
+     */
+    public function __construct(
+        private readonly array $whitelist,
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function allowedOperators(string $resourceType, string $fieldPath): array
+    {
+        return $this->whitelist[$resourceType][$fieldPath] ?? [];
+    }
+}

--- a/tests/Unit/Filter/Parser/FilterParserTest.php
+++ b/tests/Unit/Filter/Parser/FilterParserTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Unit\Filter\Parser;
+
+use JsonApi\Symfony\Filter\Ast\Comparison;
+use JsonApi\Symfony\Filter\Ast\Conjunction;
+use JsonApi\Symfony\Filter\Ast\Disjunction;
+use JsonApi\Symfony\Filter\Ast\NullCheck;
+use JsonApi\Symfony\Filter\Parser\FilterParser;
+use PHPUnit\Framework\TestCase;
+
+final class FilterParserTest extends TestCase
+{
+    public function testReturnsNullWhenNoFiltersAreProvided(): void
+    {
+        $parser = new FilterParser();
+
+        self::assertNull($parser->parse([]));
+    }
+
+    public function testParsesSimpleEqualityComparison(): void
+    {
+        $parser = new FilterParser();
+
+        $ast = $parser->parse(['title' => 'Dune']);
+
+        self::assertInstanceOf(Comparison::class, $ast);
+        self::assertSame('title', $ast->fieldPath);
+        self::assertSame('eq', $ast->operator);
+        self::assertSame(['Dune'], $ast->values);
+    }
+
+    public function testMergesMultipleFieldsIntoConjunction(): void
+    {
+        $parser = new FilterParser();
+
+        $ast = $parser->parse([
+            'title' => 'Dune',
+            'year' => ['gte' => 1965],
+        ]);
+
+        self::assertInstanceOf(Conjunction::class, $ast);
+        self::assertCount(2, $ast->children);
+        self::assertContainsOnlyInstancesOf(Comparison::class, $ast->children);
+    }
+
+    public function testParsesInOperatorFromSequentialValues(): void
+    {
+        $parser = new FilterParser();
+
+        $ast = $parser->parse(['tags' => ['sci-fi', 'classic']]);
+
+        self::assertInstanceOf(Comparison::class, $ast);
+        self::assertSame('in', $ast->operator);
+        self::assertSame(['sci-fi', 'classic'], $ast->values);
+    }
+
+    public function testParsesDisjunctionGroup(): void
+    {
+        $parser = new FilterParser();
+
+        $ast = $parser->parse([
+            'or' => [
+                ['title' => 'Dune'],
+                ['title' => 'Dune Messiah'],
+            ],
+        ]);
+
+        self::assertInstanceOf(Disjunction::class, $ast);
+        self::assertCount(2, $ast->children);
+        self::assertContainsOnlyInstancesOf(Comparison::class, $ast->children);
+    }
+
+    public function testParsesNullCheck(): void
+    {
+        $parser = new FilterParser();
+
+        $ast = $parser->parse(['publishedAt' => ['isnull' => true]]);
+
+        self::assertInstanceOf(NullCheck::class, $ast);
+        self::assertTrue($ast->isNull);
+    }
+
+    public function testCombinesMultipleOperatorsForSameField(): void
+    {
+        $parser = new FilterParser();
+
+        $ast = $parser->parse(['year' => ['gte' => 1965, 'lte' => 1985]]);
+
+        self::assertInstanceOf(Conjunction::class, $ast);
+        self::assertCount(2, $ast->children);
+        self::assertContainsOnlyInstancesOf(Comparison::class, $ast->children);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce filter AST node classes and parser placeholder
- add extensible operator contracts, registry, and stub implementations
- scaffold doctrine compiler, join manager, validation helpers, and search family hooks

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68e353e2de68832fa4f2d5e934829934