### PR TITLE
Add HTTP cache management and request safety limits

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JsonApi\Symfony\Bridge\Symfony\EventSubscriber\CachePreconditionsSubscriber;
 use JsonApi\Symfony\Bridge\Symfony\EventSubscriber\ContentNegotiationSubscriber;
 use JsonApi\Symfony\Http\Controller\CollectionController;
 use JsonApi\Symfony\Http\Controller\CreateResourceController;
@@ -16,7 +17,17 @@ use JsonApi\Symfony\Http\Error\CorrelationIdProvider;
 use JsonApi\Symfony\Http\Error\ErrorBuilder;
 use JsonApi\Symfony\Http\Error\ErrorMapper;
 use JsonApi\Symfony\Http\Error\JsonApiExceptionListener;
+use JsonApi\Symfony\Http\Cache\CacheKeyBuilder;
+use JsonApi\Symfony\Http\Cache\ConditionalRequestEvaluator;
+use JsonApi\Symfony\Http\Cache\EtagGeneratorInterface;
+use JsonApi\Symfony\Http\Cache\HashEtagGenerator;
+use JsonApi\Symfony\Http\Cache\HeadersApplier;
+use JsonApi\Symfony\Http\Cache\LastModifiedResolver;
+use JsonApi\Symfony\Http\Cache\SurrogateKeyBuilder;
+use JsonApi\Symfony\Http\Cache\VersionEtagGenerator;
 use JsonApi\Symfony\Http\Link\LinkGenerator;
+use JsonApi\Symfony\Http\Safety\LimitsEnforcer;
+use JsonApi\Symfony\Http\Safety\RequestComplexityScorer;
 use JsonApi\Symfony\Http\Request\PaginationConfig;
 use JsonApi\Symfony\Http\Request\QueryParser;
 use JsonApi\Symfony\Http\Request\SortingWhitelist;
@@ -29,6 +40,9 @@ use JsonApi\Symfony\Http\Write\RelationshipDocumentValidator;
 use JsonApi\Symfony\Http\Write\WriteConfig;
 use JsonApi\Symfony\Resource\Registry\ResourceRegistry;
 use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use JsonApi\Symfony\Invalidation\InvalidationDispatcher;
+use JsonApi\Symfony\Invalidation\NullPurger;
+use JsonApi\Symfony\Invalidation\SurrogatePurgerInterface;
 use JsonApi\Symfony\Contract\Data\ExistenceChecker;
 use JsonApi\Symfony\Contract\Data\RelationshipReader;
 use JsonApi\Symfony\Contract\Data\RelationshipUpdater;
@@ -47,6 +61,83 @@ return static function (ContainerConfigurator $configurator): void {
         ->args([
             '%jsonapi.strict_content_negotiation%',
             '%jsonapi.media_type%',
+        ])
+        ->tag('kernel.event_subscriber')
+    ;
+
+    $services->set(RequestComplexityScorer::class);
+
+    $services
+        ->set(LimitsEnforcer::class)
+        ->args([
+            service(ErrorMapper::class),
+            service(RequestComplexityScorer::class),
+            '%jsonapi.limits%',
+        ])
+    ;
+
+    $services
+        ->set(CacheKeyBuilder::class)
+        ->args([
+            '%jsonapi.cache%',
+        ])
+    ;
+
+    $services
+        ->set(HashEtagGenerator::class)
+        ->args([
+            '%jsonapi.cache%',
+        ])
+    ;
+
+    $services->set(VersionEtagGenerator::class);
+
+    $services->alias(EtagGeneratorInterface::class, HashEtagGenerator::class);
+
+    $services->set(LastModifiedResolver::class);
+
+    $services
+        ->set(ConditionalRequestEvaluator::class)
+        ->args([
+            service(ErrorMapper::class),
+            '%jsonapi.cache%',
+        ])
+    ;
+
+    $services
+        ->set(HeadersApplier::class)
+        ->args([
+            '%jsonapi.cache%',
+        ])
+    ;
+
+    $services
+        ->set(SurrogateKeyBuilder::class)
+        ->args([
+            '%jsonapi.cache%',
+        ])
+    ;
+
+    $services->set(NullPurger::class);
+    $services->alias(SurrogatePurgerInterface::class, NullPurger::class);
+
+    $services
+        ->set(InvalidationDispatcher::class)
+        ->args([
+            service(SurrogatePurgerInterface::class),
+        ])
+    ;
+
+    $services
+        ->set(CachePreconditionsSubscriber::class)
+        ->args([
+            '%jsonapi.cache%',
+            service(CacheKeyBuilder::class),
+            service(EtagGeneratorInterface::class),
+            service(LastModifiedResolver::class),
+            service(ConditionalRequestEvaluator::class),
+            service(HeadersApplier::class),
+            service(SurrogateKeyBuilder::class),
         ])
         ->tag('kernel.event_subscriber')
     ;
@@ -109,6 +200,7 @@ return static function (ContainerConfigurator $configurator): void {
             service(PaginationConfig::class),
             service(SortingWhitelist::class),
             service(ErrorMapper::class),
+            service(LimitsEnforcer::class),
         ])
     ;
 
@@ -131,6 +223,7 @@ return static function (ContainerConfigurator $configurator): void {
             service(PropertyAccessorInterface::class),
             service(LinkGenerator::class),
             '%jsonapi.relationships.linkage_in_resource%',
+            service(LimitsEnforcer::class),
         ])
     ;
 

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -82,6 +82,98 @@ final class Configuration implements ConfigurationInterface
         $errorsChildren->scalarNode('locale')->defaultNull()->end();
         $errors->end();
 
+        $this->addCacheSection($children);
+        $this->addLimitsSection($children);
+        $this->addPerformanceSection($children);
+
         return $treeBuilder;
+    }
+
+    private function addCacheSection(NodeBuilder $root): void
+    {
+        $cache = $root->arrayNode('cache')->addDefaultsIfNotSet();
+        $cacheChildren = $cache->children();
+        $cacheChildren->booleanNode('enabled')->defaultTrue()->end();
+
+        $etag = $cacheChildren->arrayNode('etag')->addDefaultsIfNotSet();
+        $etagChildren = $etag->children();
+        $etagChildren->enumNode('strategy')->values(['hash', 'version'])->defaultValue('hash')->end();
+        $etagChildren->scalarNode('hash_algo')->defaultValue('xxh3')->end();
+        $etagChildren->booleanNode('weak_for_collections')->defaultTrue()->end();
+        $etagChildren->booleanNode('include_query_shape')->defaultTrue()->end();
+        $etag->end();
+
+        $lastModified = $cacheChildren->arrayNode('last_modified')->addDefaultsIfNotSet();
+        $lastModifiedChildren = $lastModified->children();
+        $lastModifiedChildren->scalarNode('resource_field')->defaultValue('updatedAt')->end();
+        $lastModifiedChildren->arrayNode('per_type')->useAttributeAsKey('type')->scalarPrototype()->end()->defaultValue([])->end();
+        $lastModifiedChildren->booleanNode('collections_max_of')->defaultTrue()->end();
+        $lastModified->end();
+
+        $headers = $cacheChildren->arrayNode('headers')->addDefaultsIfNotSet();
+        $headersChildren = $headers->children();
+        $headersChildren->booleanNode('public')->defaultTrue()->end();
+        $headersChildren->integerNode('max_age')->defaultValue(30)->min(0)->end();
+        $headersChildren->integerNode('s_maxage')->defaultValue(600)->min(0)->end();
+        $headersChildren->integerNode('stale_while_revalidate')->defaultValue(60)->min(0)->end();
+        $headersChildren->integerNode('stale_if_error')->defaultValue(300)->min(0)->end();
+        $headersChildren->booleanNode('add_age')->defaultTrue()->end();
+        $headers->end();
+
+        $vary = $cacheChildren->arrayNode('vary')->addDefaultsIfNotSet();
+        $varyChildren = $vary->children();
+        $varyChildren->booleanNode('accept')->defaultTrue()->end();
+        $varyChildren->booleanNode('accept_language')->defaultFalse()->end();
+        $vary->end();
+
+        $surrogate = $cacheChildren->arrayNode('surrogate_keys')->addDefaultsIfNotSet();
+        $surrogateChildren = $surrogate->children();
+        $surrogateChildren->booleanNode('enabled')->defaultTrue()->end();
+        $surrogateChildren->scalarNode('header_name')->defaultValue('Surrogate-Key')->end();
+        $format = $surrogateChildren->arrayNode('format')->addDefaultsIfNotSet();
+        $formatChildren = $format->children();
+        $formatChildren->scalarNode('resource')->defaultValue('{type}:{id}')->end();
+        $formatChildren->scalarNode('collection')->defaultValue('{type}')->end();
+        $formatChildren->scalarNode('relationship')->defaultValue('{type}:{id}:{rel}')->end();
+        $format->end();
+        $surrogate->end();
+
+        $conditional = $cacheChildren->arrayNode('conditional')->addDefaultsIfNotSet();
+        $conditionalChildren = $conditional->children();
+        $conditionalChildren->booleanNode('enable_if_none_match')->defaultTrue()->end();
+        $conditionalChildren->booleanNode('enable_if_modified_since')->defaultTrue()->end();
+        $conditionalChildren->booleanNode('enable_if_match')->defaultTrue()->end();
+        $conditionalChildren->booleanNode('enable_if_unmodified_since')->defaultTrue()->end();
+        $conditionalChildren->booleanNode('require_if_match_on_write')->defaultTrue()->end();
+        $conditional->end();
+    }
+
+    private function addLimitsSection(NodeBuilder $root): void
+    {
+        $limits = $root->arrayNode('limits')->addDefaultsIfNotSet();
+        $limitsChildren = $limits->children();
+        $limitsChildren->integerNode('include_max_depth')->defaultValue(3)->min(0)->end();
+        $limitsChildren->integerNode('include_max_paths')->defaultValue(20)->min(0)->end();
+        $limitsChildren->integerNode('fields_max_total')->defaultValue(120)->min(0)->end();
+        $limitsChildren->integerNode('page_max_size')->defaultValue(100)->min(0)->end();
+        $limitsChildren->integerNode('included_max_resources')->defaultValue(1000)->min(0)->end();
+        $limitsChildren->integerNode('complexity_budget')->defaultValue(200)->min(0)->end();
+        $limits->end();
+    }
+
+    private function addPerformanceSection(NodeBuilder $root): void
+    {
+        $performance = $root->arrayNode('performance')->addDefaultsIfNotSet();
+        $performanceChildren = $performance->children();
+        $doctrine = $performanceChildren->arrayNode('doctrine')->addDefaultsIfNotSet();
+        $doctrineChildren = $doctrine->children();
+        $doctrineChildren->booleanNode('enable_query_cache')->defaultTrue()->end();
+        $doctrineChildren->scalarNode('query_cache_pool')->defaultValue('cache.app')->end();
+        $doctrineChildren->booleanNode('enable_second_level_cache')->defaultFalse()->end();
+        $doctrineChildren->booleanNode('hydrate_partial_by_fields')->defaultTrue()->end();
+        $doctrineChildren->enumNode('default_fetch')->values(['lazy', 'eager', 'extra_lazy'])->defaultValue('lazy')->end();
+        $doctrine->end();
+        $performanceChildren->booleanNode('head_enabled')->defaultTrue()->end();
+        $performance->end();
     }
 }

--- a/src/Bridge/Symfony/DependencyInjection/JsonApiExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/JsonApiExtension.php
@@ -32,6 +32,9 @@ final class JsonApiExtension extends Extension
         $container->setParameter('jsonapi.errors.add_correlation_id', $config['errors']['add_correlation_id']);
         $container->setParameter('jsonapi.errors.default_title_map', $config['errors']['default_title_map']);
         $container->setParameter('jsonapi.errors.locale', $config['errors']['locale']);
+        $container->setParameter('jsonapi.cache', $config['cache']);
+        $container->setParameter('jsonapi.limits', $config['limits']);
+        $container->setParameter('jsonapi.performance', $config['performance']);
 
         $this->registerAutoconfiguration($container);
 

--- a/src/Bridge/Symfony/EventSubscriber/CachePreconditionsSubscriber.php
+++ b/src/Bridge/Symfony/EventSubscriber/CachePreconditionsSubscriber.php
@@ -75,10 +75,10 @@ final class CachePreconditionsSubscriber implements EventSubscriberInterface
         $etag = $this->etagGenerator->generate($request, $response, $cacheKey, $weak);
         $lastModified = $this->resolveLastModified($request, $response);
 
-        $this->conditional->evaluate($request, $response, $etag, $lastModified);
+        $this->conditional->evaluate($request, $response, $etag, $lastModified, $weak);
 
         $surrogateKeys = $this->surrogates->build($request);
-        $this->headers->apply($response, $etag, $lastModified, $surrogateKeys);
+        $this->headers->apply($response, $etag, $lastModified, $surrogateKeys, $weak);
     }
 
     private function requiresPreconditions(Request $request): bool

--- a/src/Bridge/Symfony/EventSubscriber/CachePreconditionsSubscriber.php
+++ b/src/Bridge/Symfony/EventSubscriber/CachePreconditionsSubscriber.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Bridge\Symfony\EventSubscriber;
+
+use DateTimeImmutable;
+use JsonApi\Symfony\Http\Cache\CacheKeyBuilder;
+use JsonApi\Symfony\Http\Cache\ConditionalRequestEvaluator;
+use JsonApi\Symfony\Http\Cache\EtagGeneratorInterface;
+use JsonApi\Symfony\Http\Cache\HeadersApplier;
+use JsonApi\Symfony\Http\Cache\LastModifiedResolver;
+use JsonApi\Symfony\Http\Cache\SurrogateKeyBuilder;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class CachePreconditionsSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(
+        array $config,
+        private readonly CacheKeyBuilder $cacheKeyBuilder,
+        private readonly EtagGeneratorInterface $etagGenerator,
+        private readonly LastModifiedResolver $lastModified,
+        private readonly ConditionalRequestEvaluator $conditional,
+        private readonly HeadersApplier $headers,
+        private readonly SurrogateKeyBuilder $surrogates,
+    ) {
+        $this->enabled = (bool) ($config['enabled'] ?? true);
+        $etagConfig = $config['etag'] ?? [];
+        $this->weakForCollections = (bool) ($etagConfig['weak_for_collections'] ?? true);
+    }
+
+    private bool $enabled;
+
+    private bool $weakForCollections;
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => ['onKernelResponse', -1024],
+        ];
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$this->enabled || !$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $response = $event->getResponse();
+
+        if ($this->requiresPreconditions($request)) {
+            $this->conditional->evaluate($request, $response, null, null);
+
+            return;
+        }
+
+        if (!$this->isCacheableMethod($request)) {
+            return;
+        }
+
+        if (!$this->isJsonApiResponse($response)) {
+            return;
+        }
+
+        $cacheKey = $this->cacheKeyBuilder->build($request);
+        $weak = $this->isCollectionRoute($request) && $this->weakForCollections;
+        $etag = $this->etagGenerator->generate($request, $response, $cacheKey, $weak);
+        $lastModified = $this->resolveLastModified($request, $response);
+
+        $this->conditional->evaluate($request, $response, $etag, $lastModified);
+
+        $surrogateKeys = $this->surrogates->build($request);
+        $this->headers->apply($response, $etag, $lastModified, $surrogateKeys);
+    }
+
+    private function requiresPreconditions(Request $request): bool
+    {
+        $method = strtoupper($request->getMethod());
+
+        return in_array($method, ['PATCH', 'PUT', 'DELETE'], true);
+    }
+
+    private function isCacheableMethod(Request $request): bool
+    {
+        $method = strtoupper($request->getMethod());
+
+        return in_array($method, ['GET', 'HEAD'], true);
+    }
+
+    private function isJsonApiResponse(Response $response): bool
+    {
+        $contentType = $response->headers->get('Content-Type');
+        if ($contentType === null) {
+            return false;
+        }
+
+        return str_contains(strtolower($contentType), 'application/vnd.api+json');
+    }
+
+    private function isCollectionRoute(Request $request): bool
+    {
+        return $request->attributes->get('_route') === 'jsonapi.collection';
+    }
+
+    private function resolveLastModified(Request $request, Response $response): ?DateTimeImmutable
+    {
+        return $this->lastModified->resolve($request, $response);
+    }
+}

--- a/src/Events/RelationshipChangedEvent.php
+++ b/src/Events/RelationshipChangedEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Events;
+
+final class RelationshipChangedEvent
+{
+    public function __construct(
+        public readonly string $type,
+        public readonly string $id,
+        public readonly string $relationship,
+        public readonly string $operation,
+    ) {
+    }
+}

--- a/src/Events/ResourceChangedEvent.php
+++ b/src/Events/ResourceChangedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Events;
+
+final class ResourceChangedEvent
+{
+    public function __construct(
+        public readonly string $type,
+        public readonly string $id,
+        public readonly string $operation,
+    ) {
+    }
+}

--- a/src/Http/Cache/CacheKeyBuilder.php
+++ b/src/Http/Cache/CacheKeyBuilder.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Cache;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class CacheKeyBuilder
+{
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(array $config = [])
+    {
+        $etag = $config['etag'] ?? [];
+        $this->includeQueryShape = (bool) ($etag['include_query_shape'] ?? true);
+    }
+
+    private bool $includeQueryShape;
+
+    public function build(Request $request): string
+    {
+        $parts = [
+            $request->attributes->get('_route', 'unknown'),
+            $request->attributes->get('type', ''),
+            (string) $request->attributes->get('id', ''),
+            (string) $request->attributes->get('relationship', ''),
+        ];
+
+        if ($this->includeQueryShape) {
+            $parts[] = $this->normalizeQuery($request);
+            $parts[] = $this->normalizeHeader($request->headers->get('Accept'));
+            $parts[] = $this->normalizeHeader($request->headers->get('Accept-Language'));
+        }
+
+        return implode('|', array_map(static fn ($value): string => (string) $value, $parts));
+    }
+
+    private function normalizeQuery(Request $request): string
+    {
+        $query = $request->query->all();
+        if ($query === []) {
+            return '';
+        }
+
+        ksort($query);
+
+        return http_build_query($query);
+    }
+
+    private function normalizeHeader(?string $header): string
+    {
+        if ($header === null) {
+            return '';
+        }
+
+        return strtolower(trim($header));
+    }
+}

--- a/src/Http/Cache/ConditionalRequestEvaluator.php
+++ b/src/Http/Cache/ConditionalRequestEvaluator.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Cache;
+
+use DateTimeImmutable;
+use JsonApi\Symfony\Http\Error\ErrorMapper;
+use JsonApi\Symfony\Http\Exception\PreconditionFailedException;
+use JsonApi\Symfony\Http\Exception\PreconditionRequiredException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ConditionalRequestEvaluator
+{
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(ErrorMapper $errors, array $config = [])
+    {
+        $conditional = $config['conditional'] ?? [];
+
+        $this->errors = $errors;
+        $this->requireIfMatchOnWrite = (bool) ($conditional['require_if_match_on_write'] ?? false);
+        $this->enableIfNoneMatch = (bool) ($conditional['enable_if_none_match'] ?? true);
+        $this->enableIfModifiedSince = (bool) ($conditional['enable_if_modified_since'] ?? true);
+        $this->enableIfMatch = (bool) ($conditional['enable_if_match'] ?? true);
+        $this->enableIfUnmodifiedSince = (bool) ($conditional['enable_if_unmodified_since'] ?? true);
+    }
+
+    private ErrorMapper $errors;
+
+    private bool $requireIfMatchOnWrite;
+
+    private bool $enableIfNoneMatch;
+
+    private bool $enableIfModifiedSince;
+
+    private bool $enableIfMatch;
+
+    private bool $enableIfUnmodifiedSince;
+
+    public function evaluate(Request $request, Response $response, ?string $etag, ?DateTimeImmutable $lastModified): void
+    {
+        $method = strtoupper($request->getMethod());
+
+        if ($method === 'GET' || $method === 'HEAD') {
+            $this->evaluateSafeRequest($request, $response, $etag, $lastModified);
+
+            return;
+        }
+
+        if (in_array($method, ['PATCH', 'PUT', 'DELETE', 'POST'], true)) {
+            $this->evaluateWriteRequest($request, $etag, $lastModified);
+        }
+    }
+
+    private function evaluateSafeRequest(Request $request, Response $response, ?string $etag, ?DateTimeImmutable $lastModified): void
+    {
+        $ifNoneMatch = $request->headers->get('If-None-Match');
+        if ($this->enableIfNoneMatch && $etag !== null && $ifNoneMatch !== null) {
+            foreach (explode(',', $ifNoneMatch) as $candidate) {
+                if (trim($candidate) === $etag) {
+                    $this->setNotModified($response);
+
+                    return;
+                }
+            }
+        }
+
+        $ifModifiedSince = $request->headers->get('If-Modified-Since');
+        if ($this->enableIfModifiedSince && $lastModified !== null && $ifModifiedSince !== null) {
+            $date = strtotime($ifModifiedSince);
+            if ($date !== false && $lastModified->getTimestamp() <= $date) {
+                $this->setNotModified($response);
+            }
+        }
+    }
+
+    private function setNotModified(Response $response): void
+    {
+        $response->setStatusCode(Response::HTTP_NOT_MODIFIED);
+        $response->setContent(null);
+        $response->headers->remove('Content-Length');
+    }
+
+    private function evaluateWriteRequest(Request $request, ?string $etag, ?DateTimeImmutable $lastModified): void
+    {
+        $ifMatch = $request->headers->get('If-Match');
+        if ($this->requireIfMatchOnWrite && $ifMatch === null) {
+            $error = $this->errors->invalidHeader('If-Match', 'If-Match header is required for this request.');
+
+            throw new PreconditionRequiredException([$error]);
+        }
+
+        if ($this->enableIfMatch && $etag !== null && $ifMatch !== null) {
+            $matched = false;
+            foreach (explode(',', $ifMatch) as $candidate) {
+                if (trim($candidate) === $etag) {
+                    $matched = true;
+                    break;
+                }
+            }
+
+            if (!$matched) {
+                $error = $this->errors->invalidHeader('If-Match', 'The supplied If-Match validator does not match the current resource state.');
+
+                throw new PreconditionFailedException([$error]);
+            }
+        }
+
+        $ifUnmodifiedSince = $request->headers->get('If-Unmodified-Since');
+        if ($this->enableIfUnmodifiedSince && $lastModified !== null && $ifUnmodifiedSince !== null) {
+            $date = strtotime($ifUnmodifiedSince);
+            if ($date !== false && $lastModified->getTimestamp() > $date) {
+                $error = $this->errors->invalidHeader('If-Unmodified-Since', 'The resource has been modified since the provided timestamp.');
+
+                throw new PreconditionFailedException([$error]);
+            }
+        }
+    }
+}

--- a/src/Http/Cache/EtagGeneratorInterface.php
+++ b/src/Http/Cache/EtagGeneratorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Cache;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface EtagGeneratorInterface
+{
+    public function generate(Request $request, Response $response, string $cacheKey, bool $weak): ?string;
+}

--- a/src/Http/Cache/HashEtagGenerator.php
+++ b/src/Http/Cache/HashEtagGenerator.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Cache;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class HashEtagGenerator implements EtagGeneratorInterface
+{
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(array $config = [])
+    {
+        $source = $config['etag'] ?? $config;
+        $this->algorithm = (string) ($source['hash_algo'] ?? 'xxh3');
+    }
+
+    private string $algorithm;
+
+    public function generate(Request $request, Response $response, string $cacheKey, bool $weak): ?string
+    {
+        $content = $response->getContent();
+        if ($content === false) {
+            $content = '';
+        }
+
+        $payload = $cacheKey . '\n' . $content;
+        $hash = hash($this->algorithm, $payload, false);
+        if ($hash === false) {
+            return null;
+        }
+
+        if ($weak) {
+            return sprintf('W/"%s"', $hash);
+        }
+
+        return sprintf('"%s"', $hash);
+    }
+}

--- a/src/Http/Cache/HashEtagGenerator.php
+++ b/src/Http/Cache/HashEtagGenerator.php
@@ -33,10 +33,6 @@ final class HashEtagGenerator implements EtagGeneratorInterface
             return null;
         }
 
-        if ($weak) {
-            return sprintf('W/"%s"', $hash);
-        }
-
-        return sprintf('"%s"', $hash);
+        return $hash;
     }
 }

--- a/src/Http/Cache/HeadersApplier.php
+++ b/src/Http/Cache/HeadersApplier.php
@@ -53,10 +53,10 @@ final class HeadersApplier
     /**
      * @param list<string> $surrogateKeys
      */
-    public function apply(Response $response, ?string $etag, ?DateTimeImmutable $lastModified, array $surrogateKeys = []): void
+    public function apply(Response $response, ?string $etag, ?DateTimeImmutable $lastModified, array $surrogateKeys = [], bool $weak = false): void
     {
         if ($etag !== null) {
-            $response->setEtag($etag, false);
+            $response->setEtag($etag, $weak);
         }
 
         if ($lastModified !== null) {

--- a/src/Http/Cache/HeadersApplier.php
+++ b/src/Http/Cache/HeadersApplier.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Cache;
+
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Response;
+
+final class HeadersApplier
+{
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(array $config)
+    {
+        $headers = $config['headers'] ?? [];
+        $vary = $config['vary'] ?? [];
+        $surrogate = $config['surrogate_keys'] ?? [];
+
+        $this->public = (bool) ($headers['public'] ?? true);
+        $this->maxAge = (int) ($headers['max_age'] ?? 0);
+        $this->sharedMaxAge = (int) ($headers['s_maxage'] ?? 0);
+        $this->staleWhileRevalidate = (int) ($headers['stale_while_revalidate'] ?? 0);
+        $this->staleIfError = (int) ($headers['stale_if_error'] ?? 0);
+        $this->addAge = (bool) ($headers['add_age'] ?? false);
+        $this->varyAccept = (bool) ($vary['accept'] ?? true);
+        $this->varyLanguage = (bool) ($vary['accept_language'] ?? false);
+        $this->surrogateEnabled = (bool) ($surrogate['enabled'] ?? false);
+        $this->surrogateHeader = (string) ($surrogate['header_name'] ?? 'Surrogate-Key');
+    }
+
+    private bool $public;
+
+    private int $maxAge;
+
+    private int $sharedMaxAge;
+
+    private int $staleWhileRevalidate;
+
+    private int $staleIfError;
+
+    private bool $addAge;
+
+    private bool $varyAccept;
+
+    private bool $varyLanguage;
+
+    private bool $surrogateEnabled;
+
+    private string $surrogateHeader;
+
+    /**
+     * @param list<string> $surrogateKeys
+     */
+    public function apply(Response $response, ?string $etag, ?DateTimeImmutable $lastModified, array $surrogateKeys = []): void
+    {
+        if ($etag !== null) {
+            $response->setEtag($etag, false);
+        }
+
+        if ($lastModified !== null) {
+            $response->setLastModified($lastModified);
+        }
+
+        $cacheControl = [];
+        $cacheControl[] = $this->public ? 'public' : 'private';
+        if ($this->maxAge > 0) {
+            $cacheControl[] = sprintf('max-age=%d', $this->maxAge);
+        }
+
+        if ($this->sharedMaxAge > 0) {
+            $cacheControl[] = sprintf('s-maxage=%d', $this->sharedMaxAge);
+        }
+
+        if ($this->staleWhileRevalidate > 0) {
+            $cacheControl[] = sprintf('stale-while-revalidate=%d', $this->staleWhileRevalidate);
+        }
+
+        if ($this->staleIfError > 0) {
+            $cacheControl[] = sprintf('stale-if-error=%d', $this->staleIfError);
+        }
+
+        if ($cacheControl !== []) {
+            $response->headers->set('Cache-Control', implode(', ', $cacheControl));
+        }
+
+        $vary = [];
+        if ($this->varyAccept) {
+            $vary[] = 'Accept';
+        }
+
+        if ($this->varyLanguage) {
+            $vary[] = 'Accept-Language';
+        }
+
+        if ($vary !== []) {
+            $response->headers->set('Vary', implode(', ', $vary));
+        }
+
+        if ($this->addAge) {
+            $response->headers->set('Age', '0');
+        }
+
+        if ($this->surrogateEnabled && $surrogateKeys !== []) {
+            $response->headers->set($this->surrogateHeader, implode(' ', $surrogateKeys));
+        }
+    }
+}

--- a/src/Http/Cache/LastModifiedResolver.php
+++ b/src/Http/Cache/LastModifiedResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Cache;
+
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class LastModifiedResolver
+{
+    public function resolve(Request $request, Response $response): ?DateTimeImmutable
+    {
+        $header = $response->headers->get('Last-Modified');
+        if ($header !== null) {
+            $time = strtotime($header);
+            if ($time !== false) {
+                return new DateTimeImmutable('@' . $time);
+            }
+        }
+
+        return new DateTimeImmutable();
+    }
+}

--- a/src/Http/Cache/SurrogateKeyBuilder.php
+++ b/src/Http/Cache/SurrogateKeyBuilder.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Cache;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class SurrogateKeyBuilder
+{
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(array $config = [])
+    {
+        $format = $config['surrogate_keys']['format'] ?? ($config['format'] ?? []);
+        $this->resourceFormat = $format['resource'] ?? '{type}:{id}';
+        $this->collectionFormat = $format['collection'] ?? '{type}';
+        $this->relationshipFormat = $format['relationship'] ?? '{type}:{id}:{rel}';
+    }
+
+    private string $resourceFormat;
+
+    private string $collectionFormat;
+
+    private string $relationshipFormat;
+
+    public function build(Request $request): array
+    {
+        $route = (string) $request->attributes->get('_route', '');
+        $type = (string) $request->attributes->get('type', '');
+        $id = (string) $request->attributes->get('id', '');
+        $relationship = (string) $request->attributes->get('relationship', '');
+
+        if ($route === 'jsonapi.collection') {
+            return $type === '' ? [] : [$this->format($this->collectionFormat, $type, $id, $relationship)];
+        }
+
+        if ($route === 'jsonapi.resource' || $route === 'jsonapi.related' || str_contains($route, 'relationship')) {
+            $keys = [];
+            if ($type !== '') {
+                $keys[] = $this->format($this->collectionFormat, $type, $id, $relationship);
+            }
+
+            if ($type !== '' && $id !== '') {
+                $keys[] = $this->format($this->resourceFormat, $type, $id, $relationship);
+            }
+
+            if ($relationship !== '' && $type !== '' && $id !== '') {
+                $keys[] = $this->format($this->relationshipFormat, $type, $id, $relationship);
+            }
+
+            return array_values(array_unique($keys));
+        }
+
+        return [];
+    }
+
+    private function format(string $format, string $type, string $id, string $relationship): string
+    {
+        return strtr($format, [
+            '{type}' => $type,
+            '{id}' => $id,
+            '{rel}' => $relationship,
+        ]);
+    }
+}

--- a/src/Http/Cache/VersionEtagGenerator.php
+++ b/src/Http/Cache/VersionEtagGenerator.php
@@ -26,10 +26,6 @@ final class VersionEtagGenerator implements EtagGeneratorInterface
             return null;
         }
 
-        if ($weak) {
-            return sprintf('W/"%s"', $normalized);
-        }
-
-        return sprintf('"%s"', $normalized);
+        return $normalized;
     }
 }

--- a/src/Http/Cache/VersionEtagGenerator.php
+++ b/src/Http/Cache/VersionEtagGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Cache;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class VersionEtagGenerator implements EtagGeneratorInterface
+{
+    public function __construct(
+        private readonly string $headerName = 'X-Resource-Version',
+    ) {
+    }
+
+    public function generate(Request $request, Response $response, string $cacheKey, bool $weak): ?string
+    {
+        $version = $response->headers->get($this->headerName);
+        if ($version === null) {
+            return null;
+        }
+
+        $normalized = trim($version);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if ($weak) {
+            return sprintf('W/"%s"', $normalized);
+        }
+
+        return sprintf('"%s"', $normalized);
+    }
+}

--- a/src/Http/Document/DocumentBuilder.php
+++ b/src/Http/Document/DocumentBuilder.php
@@ -6,6 +6,7 @@ namespace JsonApi\Symfony\Http\Document;
 
 use JsonApi\Symfony\Contract\Data\Slice;
 use JsonApi\Symfony\Http\Link\LinkGenerator;
+use JsonApi\Symfony\Http\Safety\LimitsEnforcer;
 use JsonApi\Symfony\Query\Criteria;
 use JsonApi\Symfony\Resource\Metadata\AttributeMetadata;
 use JsonApi\Symfony\Resource\Metadata\RelationshipMetadata;
@@ -23,6 +24,7 @@ final class DocumentBuilder
         private readonly PropertyAccessorInterface $accessor,
         private readonly LinkGenerator $links,
         private readonly string $relationshipLinkageMode = 'when_included',
+        private readonly ?LimitsEnforcer $limits = null,
     ) {
     }
 
@@ -66,6 +68,7 @@ final class DocumentBuilder
         ];
 
         if ($included !== []) {
+            $this->limits?->assertIncludedCount(count($included));
             $document['included'] = array_values($included);
         }
 
@@ -103,6 +106,7 @@ final class DocumentBuilder
         ];
 
         if ($included !== []) {
+            $this->limits?->assertIncludedCount(count($included));
             $document['included'] = array_values($included);
         }
 

--- a/src/Http/Error/ErrorCodes.php
+++ b/src/Http/Error/ErrorCodes.php
@@ -23,5 +23,10 @@ final class ErrorCodes
     public const VALIDATION_ERROR = 'validation-error';
     public const PAGE_SIZE_TOO_LARGE = 'page-size-too-large';
     public const SORT_FIELD_NOT_ALLOWED = 'sort-field-not-allowed';
+    public const INVALID_HEADER = 'invalid-header';
+    public const PRECONDITION_FAILED = 'precondition-failed';
+    public const PRECONDITION_REQUIRED = 'precondition-required';
+    public const REQUEST_COMPLEXITY_EXCEEDED = 'request-complexity-exceeded';
+    public const INCLUDED_RESOURCES_LIMIT = 'included-resources-limit';
     public const INTERNAL_SERVER_ERROR = 'internal-server-error';
 }

--- a/src/Http/Error/ErrorMapper.php
+++ b/src/Http/Error/ErrorMapper.php
@@ -56,6 +56,11 @@ final class ErrorMapper
         return $this->builder->fromPointer($status, $code, null, $detail, $pointer);
     }
 
+    public function invalidHeader(string $header, string $detail, string $status = '400', string $code = ErrorCodes::INVALID_HEADER): ErrorObject
+    {
+        return $this->builder->fromHeader($status, $code, null, $detail, $header);
+    }
+
     public function unknownType(string $type): ErrorObject
     {
         return $this->builder->create(
@@ -114,6 +119,21 @@ final class ErrorMapper
             sprintf('Sorting by "%s" is not allowed for resource type "%s".', $field, $type),
             '400',
             ErrorCodes::SORT_FIELD_NOT_ALLOWED,
+        );
+    }
+
+    public function requestTooComplex(string $detail): ErrorObject
+    {
+        return $this->builder->create('400', ErrorCodes::REQUEST_COMPLEXITY_EXCEEDED, null, $detail);
+    }
+
+    public function includedResourcesLimit(int $limit): ErrorObject
+    {
+        return $this->builder->create(
+            '400',
+            ErrorCodes::INCLUDED_RESOURCES_LIMIT,
+            null,
+            sprintf('The request would include more than %d related resources.', $limit),
         );
     }
 

--- a/src/Http/Error/ErrorTitles.php
+++ b/src/Http/Error/ErrorTitles.php
@@ -27,6 +27,11 @@ final class ErrorTitles
         ErrorCodes::VALIDATION_ERROR => 'Validation error',
         ErrorCodes::PAGE_SIZE_TOO_LARGE => 'Page size too large',
         ErrorCodes::SORT_FIELD_NOT_ALLOWED => 'Sort field not allowed',
+        ErrorCodes::INVALID_HEADER => 'Invalid header',
+        ErrorCodes::PRECONDITION_FAILED => 'Precondition failed',
+        ErrorCodes::PRECONDITION_REQUIRED => 'Precondition required',
+        ErrorCodes::REQUEST_COMPLEXITY_EXCEEDED => 'Request too complex',
+        ErrorCodes::INCLUDED_RESOURCES_LIMIT => 'Included resources limit exceeded',
         ErrorCodes::INTERNAL_SERVER_ERROR => 'Internal server error',
     ];
 }

--- a/src/Http/Exception/PreconditionFailedException.php
+++ b/src/Http/Exception/PreconditionFailedException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Exception;
+
+use JsonApi\Symfony\Http\Error\ErrorObject;
+
+final class PreconditionFailedException extends JsonApiHttpException
+{
+    /**
+     * @param list<ErrorObject> $errors
+     * @param array<string, string> $headers
+     */
+    public function __construct(array $errors, array $headers = [], ?\Throwable $previous = null)
+    {
+        parent::__construct(412, 'Precondition failed.', $headers, $errors, $previous);
+    }
+}

--- a/src/Http/Exception/PreconditionRequiredException.php
+++ b/src/Http/Exception/PreconditionRequiredException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Exception;
+
+use JsonApi\Symfony\Http\Error\ErrorObject;
+
+final class PreconditionRequiredException extends JsonApiHttpException
+{
+    /**
+     * @param list<ErrorObject> $errors
+     * @param array<string, string> $headers
+     */
+    public function __construct(array $errors, array $headers = [], ?\Throwable $previous = null)
+    {
+        parent::__construct(428, 'Precondition required.', $headers, $errors, $previous);
+    }
+}

--- a/src/Http/Request/QueryParser.php
+++ b/src/Http/Request/QueryParser.php
@@ -13,6 +13,7 @@ use JsonApi\Symfony\Query\Pagination;
 use JsonApi\Symfony\Query\Sorting;
 use JsonApi\Symfony\Resource\Metadata\ResourceMetadata;
 use JsonApi\Symfony\Resource\Registry\ResourceRegistryInterface;
+use JsonApi\Symfony\Http\Safety\LimitsEnforcer;
 use Symfony\Component\HttpFoundation\Request;
 
 final class QueryParser
@@ -22,6 +23,7 @@ final class QueryParser
         private readonly PaginationConfig $paginationConfig,
         private readonly SortingWhitelist $sortingWhitelist,
         private readonly ErrorMapper $errors,
+        private readonly ?LimitsEnforcer $limits = null,
     ) {
     }
 
@@ -33,6 +35,8 @@ final class QueryParser
         $criteria->fields = $this->parseFields($request);
         $criteria->include = $this->parseInclude($type, $request);
         $criteria->sort = $this->parseSort($type, $request);
+
+        $this->limits?->enforce($type, $criteria);
 
         return $criteria;
     }

--- a/src/Http/Safety/LimitsEnforcer.php
+++ b/src/Http/Safety/LimitsEnforcer.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Safety;
+
+use JsonApi\Symfony\Http\Error\ErrorMapper;
+use JsonApi\Symfony\Http\Exception\BadRequestException;
+use JsonApi\Symfony\Query\Criteria;
+
+final class LimitsEnforcer
+{
+    /**
+     * @param array<string, int> $config
+     */
+    public function __construct(
+        private readonly ErrorMapper $errors,
+        private readonly RequestComplexityScorer $scorer,
+        private readonly array $config,
+    ) {
+    }
+
+    public function enforce(string $type, Criteria $criteria): void
+    {
+        $this->enforceIncludeLimits($criteria);
+        $this->enforceFieldsLimits($criteria);
+        $this->enforcePagination($criteria);
+        $this->enforceComplexity($criteria);
+    }
+
+    public function assertIncludedCount(int $count): void
+    {
+        $limit = $this->config['included_max_resources'] ?? 0;
+        if ($limit > 0 && $count > $limit) {
+            $error = $this->errors->includedResourcesLimit($limit);
+
+            throw new BadRequestException('Too many included resources.', [$error]);
+        }
+    }
+
+    private function enforceIncludeLimits(Criteria $criteria): void
+    {
+        $maxPaths = $this->config['include_max_paths'] ?? 0;
+        if ($maxPaths > 0 && count($criteria->include) > $maxPaths) {
+            $error = $this->errors->invalidParameter('include', sprintf('Only %d include paths are allowed per request.', $maxPaths));
+
+            throw new BadRequestException('Too many include paths.', [$error]);
+        }
+
+        $maxDepth = $this->config['include_max_depth'] ?? 0;
+        if ($maxDepth <= 0) {
+            return;
+        }
+
+        foreach ($criteria->include as $path) {
+            $depth = substr_count($path, '.') + 1;
+            if ($depth > $maxDepth) {
+                $error = $this->errors->invalidParameter('include', sprintf('Include depth cannot exceed %d.', $maxDepth));
+
+                throw new BadRequestException('Include depth exceeded.', [$error]);
+            }
+        }
+    }
+
+    private function enforceFieldsLimits(Criteria $criteria): void
+    {
+        $fieldsLimit = $this->config['fields_max_total'] ?? 0;
+        if ($fieldsLimit <= 0) {
+            return;
+        }
+
+        $total = 0;
+        foreach ($criteria->fields as $fields) {
+            $total += count($fields);
+        }
+
+        if ($total > $fieldsLimit) {
+            $error = $this->errors->invalidParameter('fields', sprintf('A maximum of %d fields can be requested.', $fieldsLimit));
+
+            throw new BadRequestException('Too many fields requested.', [$error]);
+        }
+    }
+
+    private function enforcePagination(Criteria $criteria): void
+    {
+        $pageMax = $this->config['page_max_size'] ?? 0;
+        if ($pageMax > 0 && $criteria->pagination->pageSize > $pageMax) {
+            $error = $this->errors->invalidParameter('page[size]', sprintf('Page size cannot be greater than %d.', $pageMax));
+
+            throw new BadRequestException('Page size too large.', [$error]);
+        }
+    }
+
+    private function enforceComplexity(Criteria $criteria): void
+    {
+        $budget = $this->config['complexity_budget'] ?? 0;
+        if ($budget <= 0) {
+            return;
+        }
+
+        $score = $this->scorer->score($criteria);
+        if ($score > $budget) {
+            $error = $this->errors->requestTooComplex(sprintf('The request complexity score of %d exceeds the allowed budget of %d.', $score, $budget));
+
+            throw new BadRequestException('Request too complex.', [$error]);
+        }
+    }
+}

--- a/src/Http/Safety/LimitsEnforcer.php
+++ b/src/Http/Safety/LimitsEnforcer.php
@@ -84,7 +84,7 @@ final class LimitsEnforcer
     private function enforcePagination(Criteria $criteria): void
     {
         $pageMax = $this->config['page_max_size'] ?? 0;
-        if ($pageMax > 0 && $criteria->pagination->pageSize > $pageMax) {
+        if ($pageMax > 0 && $criteria->pagination->size > $pageMax) {
             $error = $this->errors->invalidParameter('page[size]', sprintf('Page size cannot be greater than %d.', $pageMax));
 
             throw new BadRequestException('Page size too large.', [$error]);

--- a/src/Http/Safety/RequestComplexityScorer.php
+++ b/src/Http/Safety/RequestComplexityScorer.php
@@ -22,7 +22,7 @@ final class RequestComplexityScorer
         }
 
         $score += count($criteria->sort) * 2;
-        $score += $criteria->pagination->pageSize;
+        $score += $criteria->pagination->size;
 
         return $score;
     }

--- a/src/Http/Safety/RequestComplexityScorer.php
+++ b/src/Http/Safety/RequestComplexityScorer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Http\Safety;
+
+use JsonApi\Symfony\Query\Criteria;
+
+final class RequestComplexityScorer
+{
+    public function score(Criteria $criteria): int
+    {
+        $score = 0;
+
+        foreach ($criteria->include as $path) {
+            $depth = substr_count($path, '.') + 1;
+            $score += $depth * $depth;
+        }
+
+        foreach ($criteria->fields as $fields) {
+            $score += count($fields);
+        }
+
+        $score += count($criteria->sort) * 2;
+        $score += $criteria->pagination->pageSize;
+
+        return $score;
+    }
+}

--- a/src/Invalidation/InvalidationDispatcher.php
+++ b/src/Invalidation/InvalidationDispatcher.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Invalidation;
+
+final class InvalidationDispatcher
+{
+    public function __construct(private readonly SurrogatePurgerInterface $purger)
+    {
+    }
+
+    /**
+     * @param list<string> $keys
+     */
+    public function invalidate(array $keys): void
+    {
+        if ($keys === []) {
+            return;
+        }
+
+        $this->purger->purge(array_values(array_unique($keys)));
+    }
+}

--- a/src/Invalidation/NullPurger.php
+++ b/src/Invalidation/NullPurger.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Invalidation;
+
+final class NullPurger implements SurrogatePurgerInterface
+{
+    public function purge(array $keys): void
+    {
+        // no-op
+    }
+}

--- a/src/Invalidation/SurrogatePurgerInterface.php
+++ b/src/Invalidation/SurrogatePurgerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Invalidation;
+
+interface SurrogatePurgerInterface
+{
+    /**
+     * @param list<string> $keys
+     */
+    public function purge(array $keys): void;
+}

--- a/tests/Unit/Http/Cache/ConditionalRequestEvaluatorTest.php
+++ b/tests/Unit/Http/Cache/ConditionalRequestEvaluatorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Unit\Http\Cache;
+
+use JsonApi\Symfony\Http\Cache\ConditionalRequestEvaluator;
+use JsonApi\Symfony\Http\Error\ErrorBuilder;
+use JsonApi\Symfony\Http\Error\ErrorMapper;
+use JsonApi\Symfony\Http\Exception\PreconditionFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ConditionalRequestEvaluatorTest extends TestCase
+{
+    public function testIfNoneMatchTriggersNotModifiedForQuotedValidator(): void
+    {
+        $evaluator = $this->createEvaluator();
+        $request = Request::create('/articles', 'GET');
+        $request->headers->set('If-None-Match', '"hash"');
+        $response = new Response();
+
+        $evaluator->evaluate($request, $response, 'hash', null);
+
+        self::assertSame(Response::HTTP_NOT_MODIFIED, $response->getStatusCode());
+    }
+
+    public function testIfNoneMatchHandlesWeakValidators(): void
+    {
+        $evaluator = $this->createEvaluator();
+        $request = Request::create('/articles', 'GET');
+        $request->headers->set('If-None-Match', 'W/"hash"');
+        $response = new Response();
+
+        $evaluator->evaluate($request, $response, 'hash', null);
+
+        self::assertSame(Response::HTTP_NOT_MODIFIED, $response->getStatusCode());
+    }
+
+    public function testIfMatchRejectsWeakValidators(): void
+    {
+        $evaluator = $this->createEvaluator();
+        $request = Request::create('/articles', 'PATCH');
+        $request->headers->set('If-Match', 'W/"hash"');
+
+        $this->expectException(PreconditionFailedException::class);
+
+        $evaluator->evaluate($request, new Response(), 'hash', null, false);
+    }
+
+    public function testIfMatchAcceptsStrongValidators(): void
+    {
+        $evaluator = $this->createEvaluator();
+        $request = Request::create('/articles', 'PATCH');
+        $request->headers->set('If-Match', '"hash"');
+
+        $evaluator->evaluate($request, new Response(), 'hash', null, false);
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function createEvaluator(): ConditionalRequestEvaluator
+    {
+        $builder = new ErrorBuilder(true);
+        $mapper = new ErrorMapper($builder);
+
+        return new ConditionalRequestEvaluator($mapper);
+    }
+}

--- a/tests/Unit/Http/Cache/ConditionalRequestEvaluatorTest.php
+++ b/tests/Unit/Http/Cache/ConditionalRequestEvaluatorTest.php
@@ -8,6 +8,7 @@ use JsonApi\Symfony\Http\Cache\ConditionalRequestEvaluator;
 use JsonApi\Symfony\Http\Error\ErrorBuilder;
 use JsonApi\Symfony\Http\Error\ErrorMapper;
 use JsonApi\Symfony\Http\Exception\PreconditionFailedException;
+use JsonApi\Symfony\Http\Exception\PreconditionRequiredException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -38,6 +39,30 @@ final class ConditionalRequestEvaluatorTest extends TestCase
         self::assertSame(Response::HTTP_NOT_MODIFIED, $response->getStatusCode());
     }
 
+    public function testIfNoneMatchWildcardTriggersNotModified(): void
+    {
+        $evaluator = $this->createEvaluator();
+        $request = Request::create('/articles', 'GET');
+        $request->headers->set('If-None-Match', '*');
+        $response = new Response();
+
+        $evaluator->evaluate($request, $response, 'hash', null);
+
+        self::assertSame(Response::HTTP_NOT_MODIFIED, $response->getStatusCode());
+    }
+
+    public function testIfNoneMatchMatchesAmongMultipleValidators(): void
+    {
+        $evaluator = $this->createEvaluator();
+        $request = Request::create('/articles', 'GET');
+        $request->headers->set('If-None-Match', '"other", W/"hash"');
+        $response = new Response();
+
+        $evaluator->evaluate($request, $response, 'hash', null);
+
+        self::assertSame(Response::HTTP_NOT_MODIFIED, $response->getStatusCode());
+    }
+
     public function testIfMatchRejectsWeakValidators(): void
     {
         $evaluator = $this->createEvaluator();
@@ -47,6 +72,17 @@ final class ConditionalRequestEvaluatorTest extends TestCase
         $this->expectException(PreconditionFailedException::class);
 
         $evaluator->evaluate($request, new Response(), 'hash', null, false);
+    }
+
+    public function testIfMatchAcceptsUnquotedValidator(): void
+    {
+        $evaluator = $this->createEvaluator();
+        $request = Request::create('/articles', 'PATCH');
+        $request->headers->set('If-Match', 'hash');
+
+        $evaluator->evaluate($request, new Response(), 'hash', null, false);
+
+        $this->addToAssertionCount(1);
     }
 
     public function testIfMatchAcceptsStrongValidators(): void
@@ -60,11 +96,23 @@ final class ConditionalRequestEvaluatorTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    private function createEvaluator(): ConditionalRequestEvaluator
+    public function testIfMatchHeaderRequiredWhenConfigured(): void
+    {
+        $evaluator = $this->createEvaluator([
+            'conditional' => ['require_if_match_on_write' => true],
+        ]);
+        $request = Request::create('/articles', 'PATCH');
+
+        $this->expectException(PreconditionRequiredException::class);
+
+        $evaluator->evaluate($request, new Response(), 'hash', null, false);
+    }
+
+    private function createEvaluator(array $config = []): ConditionalRequestEvaluator
     {
         $builder = new ErrorBuilder(true);
         $mapper = new ErrorMapper($builder);
 
-        return new ConditionalRequestEvaluator($mapper);
+        return new ConditionalRequestEvaluator($mapper, $config);
     }
 }

--- a/tests/Unit/Http/Cache/HashEtagGeneratorTest.php
+++ b/tests/Unit/Http/Cache/HashEtagGeneratorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Unit\Http\Cache;
+
+use JsonApi\Symfony\Http\Cache\HashEtagGenerator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class HashEtagGeneratorTest extends TestCase
+{
+    public function testGenerateReturnsRawHash(): void
+    {
+        $generator = new HashEtagGenerator(['etag' => ['hash_algo' => 'md5']]);
+        $request = new Request();
+        $response = new Response('content');
+
+        $etag = $generator->generate($request, $response, 'cache-key', false);
+
+        self::assertSame(hash('md5', 'cache-key\\ncontent'), $etag);
+    }
+}

--- a/tests/Unit/Http/Cache/HeadersApplierTest.php
+++ b/tests/Unit/Http/Cache/HeadersApplierTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Unit\Http\Cache;
+
+use JsonApi\Symfony\Http\Cache\HeadersApplier;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class HeadersApplierTest extends TestCase
+{
+    public function testAppliesStrongEtagWithoutDoubleQuoting(): void
+    {
+        $response = new Response();
+        $applier = new HeadersApplier([]);
+
+        $applier->apply($response, 'hash', null);
+
+        self::assertSame('"hash"', $response->headers->get('ETag'));
+    }
+
+    public function testAppliesWeakEtagFlag(): void
+    {
+        $response = new Response();
+        $applier = new HeadersApplier([]);
+
+        $applier->apply($response, 'hash', null, [], true);
+
+        self::assertSame('W/"hash"', $response->headers->get('ETag'));
+    }
+}

--- a/tests/Unit/Http/Cache/VersionEtagGeneratorTest.php
+++ b/tests/Unit/Http/Cache/VersionEtagGeneratorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Unit\Http\Cache;
+
+use JsonApi\Symfony\Http\Cache\VersionEtagGenerator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class VersionEtagGeneratorTest extends TestCase
+{
+    public function testGenerateReturnsNormalizedHeaderValue(): void
+    {
+        $generator = new VersionEtagGenerator('X-Version');
+        $request = new Request();
+        $response = new Response();
+        $response->headers->set('X-Version', '  v1  ');
+
+        $etag = $generator->generate($request, $response, 'cache-key', false);
+
+        self::assertSame('v1', $etag);
+    }
+}

--- a/tests/Unit/Http/Safety/LimitsEnforcerTest.php
+++ b/tests/Unit/Http/Safety/LimitsEnforcerTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Unit\Http\Safety;
+
+use JsonApi\Symfony\Http\Error\ErrorBuilder;
+use JsonApi\Symfony\Http\Error\ErrorCodes;
+use JsonApi\Symfony\Http\Error\ErrorMapper;
+use JsonApi\Symfony\Http\Exception\BadRequestException;
+use JsonApi\Symfony\Http\Safety\LimitsEnforcer;
+use JsonApi\Symfony\Http\Safety\RequestComplexityScorer;
+use JsonApi\Symfony\Query\Criteria;
+use JsonApi\Symfony\Query\Pagination;
+use JsonApi\Symfony\Query\Sorting;
+use PHPUnit\Framework\TestCase;
+
+final class LimitsEnforcerTest extends TestCase
+{
+    public function testAllowsRequestWithinLimits(): void
+    {
+        $criteria = $this->createCriteria();
+
+        $enforcer = $this->createEnforcer([
+            'include_max_paths' => 3,
+            'include_max_depth' => 3,
+            'fields_max_total' => 5,
+            'page_max_size' => 10,
+            'complexity_budget' => 30,
+            'included_max_resources' => 5,
+        ]);
+
+        $enforcer->enforce('articles', $criteria);
+
+        // also ensure included resources count within limit does not throw
+        $enforcer->assertIncludedCount(2);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testThrowsWhenIncludePathsExceedLimit(): void
+    {
+        $criteria = $this->createCriteria();
+        $criteria->include = ['author', 'comments'];
+
+        $enforcer = $this->createEnforcer(['include_max_paths' => 1]);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Too many include paths.');
+
+        try {
+            $enforcer->enforce('articles', $criteria);
+        } catch (BadRequestException $exception) {
+            $this->assertError($exception, ErrorCodes::INVALID_PARAMETER, 'Only 1 include paths are allowed per request.', 'include');
+
+            throw $exception;
+        }
+    }
+
+    public function testThrowsWhenIncludeDepthExceedsLimit(): void
+    {
+        $criteria = $this->createCriteria();
+        $criteria->include = ['comments.author'];
+
+        $enforcer = $this->createEnforcer(['include_max_depth' => 1]);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Include depth exceeded.');
+
+        try {
+            $enforcer->enforce('articles', $criteria);
+        } catch (BadRequestException $exception) {
+            $this->assertError($exception, ErrorCodes::INVALID_PARAMETER, 'Include depth cannot exceed 1.', 'include');
+
+            throw $exception;
+        }
+    }
+
+    public function testThrowsWhenFieldsTotalExceedsLimit(): void
+    {
+        $criteria = $this->createCriteria();
+        $criteria->fields = [
+            'articles' => ['title', 'body', 'slug'],
+            'people' => ['name', 'email'],
+        ];
+
+        $enforcer = $this->createEnforcer(['fields_max_total' => 4]);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Too many fields requested.');
+
+        try {
+            $enforcer->enforce('articles', $criteria);
+        } catch (BadRequestException $exception) {
+            $this->assertError($exception, ErrorCodes::INVALID_PARAMETER, 'A maximum of 4 fields can be requested.', 'fields');
+
+            throw $exception;
+        }
+    }
+
+    public function testThrowsWhenPageSizeExceedsLimit(): void
+    {
+        $criteria = $this->createCriteria();
+        $criteria->pagination = new Pagination(1, 25);
+
+        $enforcer = $this->createEnforcer(['page_max_size' => 20]);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Page size too large.');
+
+        try {
+            $enforcer->enforce('articles', $criteria);
+        } catch (BadRequestException $exception) {
+            $this->assertError($exception, ErrorCodes::INVALID_PARAMETER, 'Page size cannot be greater than 20.', 'page[size]');
+
+            throw $exception;
+        }
+    }
+
+    public function testThrowsWhenComplexityBudgetIsExceeded(): void
+    {
+        $criteria = $this->createCriteria();
+        $criteria->include = ['author', 'comments.author'];
+        $criteria->fields = ['articles' => ['title'], 'people' => ['name']];
+        $criteria->sort = [];
+        $criteria->pagination = new Pagination(1, 6);
+
+        $enforcer = $this->createEnforcer(['complexity_budget' => 10]);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Request too complex.');
+
+        $score = (new RequestComplexityScorer())->score($criteria);
+
+        try {
+            $enforcer->enforce('articles', $criteria);
+        } catch (BadRequestException $exception) {
+            $this->assertError(
+                $exception,
+                ErrorCodes::REQUEST_COMPLEXITY_EXCEEDED,
+                sprintf('The request complexity score of %d exceeds the allowed budget of 10.', $score),
+            );
+
+            throw $exception;
+        }
+    }
+
+    public function testAssertIncludedCountThrowsWhenLimitExceeded(): void
+    {
+        $enforcer = $this->createEnforcer(['included_max_resources' => 3]);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Too many included resources.');
+
+        try {
+            $enforcer->assertIncludedCount(5);
+        } catch (BadRequestException $exception) {
+            $this->assertError(
+                $exception,
+                ErrorCodes::INCLUDED_RESOURCES_LIMIT,
+                'The request would include more than 3 related resources.',
+            );
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * @param array<string, int> $config
+     */
+    private function createEnforcer(array $config): LimitsEnforcer
+    {
+        $builder = new ErrorBuilder(false);
+        $mapper = new ErrorMapper($builder);
+
+        return new LimitsEnforcer($mapper, new RequestComplexityScorer(), $config);
+    }
+
+    private function createCriteria(): Criteria
+    {
+        $criteria = new Criteria(new Pagination(1, 5));
+        $criteria->include = ['author'];
+        $criteria->fields = ['articles' => ['title', 'body']];
+        $criteria->sort = [new Sorting('title', false)];
+
+        return $criteria;
+    }
+
+    private function assertError(BadRequestException $exception, string $code, string $detail, ?string $parameter = null): void
+    {
+        $errors = $exception->getErrors();
+        self::assertCount(1, $errors);
+        $error = $errors[0];
+
+        self::assertSame($code, $error->code);
+        self::assertSame($detail, $error->detail);
+
+        if ($parameter !== null) {
+            self::assertSame($parameter, $error->source?->parameter);
+        }
+    }
+}

--- a/tests/Unit/Http/Safety/RequestComplexityScorerTest.php
+++ b/tests/Unit/Http/Safety/RequestComplexityScorerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonApi\Symfony\Tests\Unit\Http\Safety;
+
+use JsonApi\Symfony\Http\Safety\RequestComplexityScorer;
+use JsonApi\Symfony\Query\Criteria;
+use JsonApi\Symfony\Query\Pagination;
+use JsonApi\Symfony\Query\Sorting;
+use PHPUnit\Framework\TestCase;
+
+final class RequestComplexityScorerTest extends TestCase
+{
+    public function testScoresIncludesFieldsSortsAndPagination(): void
+    {
+        $criteria = new Criteria(new Pagination(2, 7));
+        $criteria->include = ['author', 'comments.author', 'comments.author.profile'];
+        $criteria->fields = [
+            'articles' => ['title', 'body', 'slug'],
+            'people' => ['name'],
+        ];
+        $criteria->sort = [
+            new Sorting('title', false),
+            new Sorting('createdAt', true),
+        ];
+
+        $scorer = new RequestComplexityScorer();
+
+        $score = $scorer->score($criteria);
+
+        // include score: 1^2 + 2^2 + 3^2 = 14
+        // fields score: 3 + 1 = 4
+        // sort score: 2 * 2 = 4
+        // pagination score: size 7
+        self::assertSame(29, $score);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce cache key building, ETag generation, conditional evaluation, and surrogate key helpers with a cache precondition subscriber
- add request complexity scoring and limits enforcement alongside new error codes and exceptions
- extend service wiring and configuration to expose cache, limits, and performance controls

## Testing
- php -l src/Http/Cache/CacheKeyBuilder.php
- php -l src/Http/Cache/HashEtagGenerator.php
- php -l src/Http/Cache/ConditionalRequestEvaluator.php
- php -l src/Bridge/Symfony/EventSubscriber/CachePreconditionsSubscriber.php
- php -l src/Http/Safety/LimitsEnforcer.php
- php -l src/Http/Safety/RequestComplexityScorer.php
- php -l src/Http/Document/DocumentBuilder.php
- php -l src/Http/Error/ErrorMapper.php
- php -l src/Http/Request/QueryParser.php
- php -l src/Http/Exception/PreconditionFailedException.php
- php -l src/Http/Exception/PreconditionRequiredException.php

------
https://chatgpt.com/codex/tasks/task_e_68e35d1969d4832fb45763ed36694fda